### PR TITLE
Ignore duplicate names even if configured.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -425,6 +425,24 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			if (len <= 0)
 				goto err;
 
+			uint8_t *iter = iface->search;
+			uint8_t *iter_end = iface->search + iface->search_len;
+			bool found = false;
+			while (iter < iter_end) {
+				if ((iter_end - iter) < len)
+					break;
+				if (memcmp(iter, buf, len) == 0) {
+					found = true;
+					break;
+				}
+				/* Skip non-zero label lengths */
+				while (iter < iter_end && *iter)
+					iter += (int) *iter + 1;
+				/* Skip last zero label (if any) */
+				iter++;
+			}
+			if (found) continue;
+
 			iface->search = realloc(iface->search, iface->search_len + len);
 			memcpy(&iface->search[iface->search_len], buf, len);
 			iface->search_len += len;


### PR DESCRIPTION
This will drop duplicate names from search path - they won't do anything. (Obviously, getting rid of duplicate names to start with would be the correct step, but this makes my home network look prettier right now.. _grin_)
