### PR TITLE
Bugfixes

### DIFF
--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -320,8 +320,7 @@ static void odhcpd_receive_packets(struct uloop_fd *u, _unused unsigned int even
 		int *hlim = NULL;
 		struct in6_pktinfo *pktinfo;
 		struct in_pktinfo *pkt4info;
-		for (struct cmsghdr *ch = CMSG_FIRSTHDR(&msg); ch != NULL &&
-				destiface == 0; ch = CMSG_NXTHDR(&msg, ch)) {
+		for (struct cmsghdr *ch = CMSG_FIRSTHDR(&msg); ch != NULL; ch = CMSG_NXTHDR(&msg, ch)) {
 			if (ch->cmsg_level == IPPROTO_IPV6 &&
 					ch->cmsg_type == IPV6_PKTINFO) {
 				pktinfo = (struct in6_pktinfo*)CMSG_DATA(ch);

--- a/src/router.c
+++ b/src/router.c
@@ -130,12 +130,66 @@ static void sigusr1_refresh(_unused int signal)
 			uloop_timeout_set(&iface->timer_rs, 1000);
 }
 
+static int router_icmpv6_valid(struct sockaddr_in6 *source, uint8_t *data, size_t len)
+{
+	struct icmp6_hdr *hdr = (struct icmp6_hdr *)data;
+	struct icmpv6_opt *opt;
+	size_t optlen = len - sizeof(*hdr);
+
+	/* Hoplimit is already checked in odhcpd_receive_packets */
+	if (len < sizeof(*hdr))
+		return 0;
+
+	if (hdr->icmp6_code)
+		return 0;
+
+	switch (hdr->icmp6_type) {
+	case ND_ROUTER_ADVERT:
+		if (!IN6_IS_ADDR_LINKLOCAL(&source->sin6_addr))
+			return 0;
+
+		opt = (struct icmpv6_opt *)((struct nd_router_advert *)data + 1);
+		break;
+
+	case ND_ROUTER_SOLICIT:
+		opt = (struct icmpv6_opt *)((struct nd_router_solicit *)data + 1);
+		break;
+
+	default:
+		return 0;
+	}
+
+	while (optlen > 0) {
+		size_t l = opt->len << 3;
+
+		if (optlen < sizeof(*opt))
+			return 0;
+
+		if (l > optlen || l == 0)
+			return 0;
+
+		if (opt->type == ND_OPT_SOURCE_LINKADDR && IN6_IS_ADDR_UNSPECIFIED(&source->sin6_addr) &&
+			hdr->icmp6_type == ND_ROUTER_SOLICIT) {
+			return 0;
+		}
+
+		opt = (struct icmpv6_opt *)(((uint8_t *)opt) + l);
+
+		optlen -= l;
+	}
+
+	return 1;
+}
 
 // Event handler for incoming ICMPv6 packets
-static void handle_icmpv6(_unused void *addr, void *data, size_t len,
+static void handle_icmpv6(void *addr, void *data, size_t len,
 		struct interface *iface)
 {
 	struct icmp6_hdr *hdr = data;
+	
+	if (!router_icmpv6_valid(addr, data, len))
+		return;
+
 	if ((iface->ra == RELAYD_SERVER && !iface->master)) { // Server mode
 		if (hdr->icmp6_type == ND_ROUTER_SOLICIT)
 			send_router_advert(&iface->timer_rs);

--- a/src/router.h
+++ b/src/router.h
@@ -20,15 +20,25 @@
 struct icmpv6_opt {
 	uint8_t type;
 	uint8_t len;
-	uint8_t data[6];
 };
 
+struct nd_opt_slla {
+	uint8_t type;
+	uint8_t len;
+	uint8_t addr[6];
+};
+
+struct nd_opt_recursive_dns {
+	uint8_t type;
+	uint8_t len;
+	uint8_t pad;
+	uint8_t pad2;
+	uint32_t lifetime;
+};
 
 #define icmpv6_for_each_option(opt, start, end)\
 	for (opt = (struct icmpv6_opt*)(start);\
-	(void*)(opt + 1) <= (void*)(end) && opt->len > 0 &&\
-	(void*)(opt + opt->len) <= (void*)(end); opt += opt->len)
-
+	(void*)(opt + (opt->len << 3)) <= (void*)(end); opt += (opt->len << 3))
 
 #define MaxRtrAdvInterval 600
 #define MinRtrAdvInterval (MaxRtrAdvInterval / 3)


### PR DESCRIPTION
Hi Steven,

I have worked on 3 bugfixes for the odhcpd daemon; first patch (a946e2) fixes hop limit scanning in the ancillary data while the second patch (f587736) fixes router advertisement/solicitation option parsing as the option length is variable for each option. Last patch (3f4117e5) checks the sanity of the router advertisement/solicitation messages as some logic from the previous option parsing is moved to this patch and lines up with RFC4861 regarding message checking. If you have feedback/comments regarding the patches just let me know.

Bye,
Hans
