### PR TITLE
Fixes for option parsing

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -134,7 +134,7 @@ static int router_icmpv6_valid(struct sockaddr_in6 *source, uint8_t *data, size_
 {
 	struct icmp6_hdr *hdr = (struct icmp6_hdr *)data;
 	struct icmpv6_opt *opt;
-	size_t optlen = len - sizeof(*hdr);
+	size_t optlen;
 
 	/* Hoplimit is already checked in odhcpd_receive_packets */
 	if (len < sizeof(*hdr))
@@ -149,10 +149,12 @@ static int router_icmpv6_valid(struct sockaddr_in6 *source, uint8_t *data, size_
 			return 0;
 
 		opt = (struct icmpv6_opt *)((struct nd_router_advert *)data + 1);
+		optlen = len - sizeof(struct nd_router_advert);
 		break;
 
 	case ND_ROUTER_SOLICIT:
 		opt = (struct icmpv6_opt *)((struct nd_router_solicit *)data + 1);
+		optlen = len - sizeof(struct nd_router_solicit);
 		break;
 
 	default:

--- a/src/router.h
+++ b/src/router.h
@@ -37,8 +37,10 @@ struct nd_opt_recursive_dns {
 };
 
 #define icmpv6_for_each_option(opt, start, end)\
-	for (opt = (struct icmpv6_opt*)(start);\
-	(void*)(opt + (opt->len << 3)) <= (void*)(end); opt += (opt->len << 3))
+	for (opt = (struct icmpv6_opt *)(start);\
+	((void *)opt < (void *)end) && \
+	(void *)((uint8_t *)opt + (opt->len << 3)) <= (void *)(end); \
+	opt = (struct icmpv6_opt *)((uint8_t *)opt + (opt->len << 3)))
 
 #define MaxRtrAdvInterval 600
 #define MinRtrAdvInterval (MaxRtrAdvInterval / 3)


### PR DESCRIPTION
Hi Steven,

I've made two patches for fixing issues noticed during parsing of icmpv6 options (introduced by one of my previous commits); first patch (47ee3f8) fixes issue during icmpv6 option parsing when validating the icmpv6 message while the last patch (f40d224) fixes issue in the icmpv6 option iterator macro caused by lack of valid pointer casts.

Bye,
Hans
