### PR TITLE
Fix interface ignore overwrite

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -302,6 +302,9 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	if (ifname)
 		strncpy(iface->ifname, ifname, sizeof(iface->ifname) - 1);
 
+	if ((iface->ifindex = if_nametoindex(iface->ifname)) <= 0)
+		return -1;
+
 	iface->inuse = true;
 
 	if ((c = tb[IFACE_ATTR_DYNAMICDHCP]))
@@ -494,7 +497,6 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 		}
 	}
 
-	iface->ignore = (iface->ifindex = if_nametoindex(iface->ifname)) <= 0;
 	return 0;
 
 err:


### PR DESCRIPTION
Hi Steven,

Pull requests fixes overwrite of the interface ignore parameter; which was initially set when parsing the interface UCI, and later overwritten when resolving the interface ifindex.
If the interface ifindex cannot be resolved the interface is not set in use. By not setting the interface in use the interface will be closed and no dhcpv4/6 and router initialization will be done (which requires a valid ifindex anyway). 

Bye,
Hans

cannot be setup and needs to be closed.
