### PR TITLE
Don't rearm RS timer if callback is not set

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -451,12 +451,14 @@ static void send_router_advert(struct uloop_timeout *event)
 	odhcpd_send(router_event.uloop.fd,
 			&all_nodes, iov, ARRAY_SIZE(iov), iface);
 
-	// Rearm timer
-	int msecs;
-	odhcpd_urandom(&msecs, sizeof(msecs));
-	msecs = (labs(msecs) % (1000 * (MaxRtrAdvInterval
-			- MinRtrAdvInterval))) + (MinRtrAdvInterval * 1000);
-	uloop_timeout_set(&iface->timer_rs, msecs);
+	// Rearm timer if not shut down
+	if (event->cb) {
+		int msecs;
+		odhcpd_urandom(&msecs, sizeof(msecs));
+		msecs = (labs(msecs) % (1000 * (MaxRtrAdvInterval
+				- MinRtrAdvInterval))) + (MinRtrAdvInterval * 1000);
+		uloop_timeout_set(&iface->timer_rs, msecs);
+	}
 }
 
 


### PR DESCRIPTION
Hi Steven,

Patch does not rearm the RS timer if callback is not set as it could lead to potential issues when interface is being closed due to invalid config.  

Bye,
Hans
