### PR TITLE
Fix ra_management and ndproxy_routing config overwrite

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -454,7 +454,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_RA_MANAGEMENT]))
 		iface->managed = blobmsg_get_u32(c);
-	else
+	else if (overwrite)
 		iface->managed = 1;
 
 	if ((c = tb[IFACE_ATTR_RA_OFFLINK]))
@@ -475,7 +475,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_NDPROXY_ROUTING]))
 		iface->learn_routes = blobmsg_get_bool(c);
-	else
+	else if (overwrite)
 		iface->learn_routes = true;
 
 	if ((c = tb[IFACE_ATTR_NDPROXY_SLAVE]))


### PR DESCRIPTION
Hi Steven,

During testing I observed the ra_management and ndproxy_routing UCI config was overwritten in odhcpd when ubus_apply_networkw as called as the attributes IFACE_ATTR_RA_MANAGEMENT and IFACE_ATTR_NDPROXY_ROUTING are not present in the blobmsg (and thus overwrite the initial values set by the UCI config). Solved by the issue by testing the overwrite parameter but I'm not 100% sure the parameter overwrite is intended for this purpose.
Otherwise everything seems to work fine; nice job !

Regarding 6rd I pushed a patch to the OpenWRT devel mailing list to make the "don't fragment" bit of 6rd tunnel interfaces configurable via UCI (one of my previous patches in netifd offers this support); do you see it as an usefull extension for OpenWRT as normally the "don't fragment" bit should be disabled according to the RFC while it's currently enabled.

Br,
Hans  
