### PR TITLE
Fix parsing of static ndp entries

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -494,6 +494,9 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			if (!iface->static_ndp)
 				goto err;
 
+			if (iface->static_ndp_len)
+				iface->static_ndp[iface->static_ndp_len - 1] = ' ';
+
 			memcpy(&iface->static_ndp[iface->static_ndp_len], blobmsg_get_string(cur), len);
 			iface->static_ndp_len += len;
 		}

--- a/src/ndp.c
+++ b/src/ndp.c
@@ -167,6 +167,7 @@ int setup_ndp_interface(struct interface *iface, bool enable)
 			memcpy(entry, iface->static_ndp, iface->static_ndp_len);
 
 			for (entry = strtok_r(entry, " ", &saveptr); entry; entry = strtok_r(NULL, " ", &saveptr)) {
+				char *sep;
 				struct ndp_neighbor *n = malloc(sizeof(*n));
 				if (!n) {
 					syslog(LOG_ERR, "Malloc failed for static NDP-prefix %s", entry);
@@ -176,10 +177,18 @@ int setup_ndp_interface(struct interface *iface, bool enable)
 				n->iface = iface;
 				n->timeout = 0;
 
-				char ipbuf[INET6_ADDRSTRLEN];
-				if (sscanf(entry, "%45s/%hhu", ipbuf, &n->len) < 2
-						|| n->len > 128 || inet_pton(AF_INET6, ipbuf, &n->addr) != 1) {
+				sep = strchr(entry, '/');
+				if (!sep) {
+					free(n);
 					syslog(LOG_ERR, "Invalid static NDP-prefix %s", entry);
+					return -1;
+				}
+				
+				*sep = 0;
+				n->len = atoi(sep + 1);
+				if (inet_pton(AF_INET6, entry, &n->addr) != 1 || n->len > 128) {
+					free(n);
+					syslog(LOG_ERR, "Invalid static NDP-prefix %s/%s", entry, sep + 1);
 					return -1;
 				}
 

--- a/src/ndp.c
+++ b/src/ndp.c
@@ -167,7 +167,6 @@ int setup_ndp_interface(struct interface *iface, bool enable)
 			memcpy(entry, iface->static_ndp, iface->static_ndp_len);
 
 			for (entry = strtok_r(entry, " ", &saveptr); entry; entry = strtok_r(NULL, " ", &saveptr)) {
-				char *sep;
 				struct ndp_neighbor *n = malloc(sizeof(*n));
 				if (!n) {
 					syslog(LOG_ERR, "Malloc failed for static NDP-prefix %s", entry);
@@ -177,18 +176,10 @@ int setup_ndp_interface(struct interface *iface, bool enable)
 				n->iface = iface;
 				n->timeout = 0;
 
-				sep = strchr(entry, '/');
-				if (!sep) {
-					free(n);
+				char ipbuf[INET6_ADDRSTRLEN];
+				if (sscanf(entry, "%45s/%hhu", ipbuf, &n->len) < 2
+						|| n->len > 128 || inet_pton(AF_INET6, ipbuf, &n->addr) != 1) {
 					syslog(LOG_ERR, "Invalid static NDP-prefix %s", entry);
-					return -1;
-				}
-				
-				*sep = 0;
-				n->len = atoi(sep + 1);
-				if (inet_pton(AF_INET6, entry, &n->addr) != 1 || n->len > 128) {
-					free(n);
-					syslog(LOG_ERR, "Invalid static NDP-prefix %s/%s", entry, sep + 1);
 					return -1;
 				}
 


### PR DESCRIPTION
Hi Steven,

Patch fixes parsing of static configured ndp entries. The strtok_r iteration was failing for multiple prefixes in the list as each prefix was null terminated in the static ndp parameter; additionally sscanf was failing for each entry in the list.

Hans
