### PR TITLE
Bugfixes

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1191,7 +1191,8 @@ ssize_t dhcpv6_handle_ia(uint8_t *buf, size_t buflen, struct interface *iface,
 		response_len += ia_response_len;
 	}
 
-	if (hdr->msg_type == DHCPV6_MSG_RELEASE && response_len + 6 < buflen) {
+	if ((hdr->msg_type == DHCPV6_MSG_RELEASE  || hdr->msg_type == DHCPV6_MSG_DECLINE) &&
+			response_len + 6 < buflen) {
 		buf[0] = 0;
 		buf[1] = DHCPV6_OPT_STATUS;
 		buf[2] = 0;

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -320,7 +320,7 @@ static void handle_client_request(void *addr, void *data, size_t len,
 	if (opts[-4] != DHCPV6_MSG_INFORMATION_REQUEST) {
 		ssize_t ialen = dhcpv6_handle_ia(pdbuf, sizeof(pdbuf), iface, addr, &opts[-4], opts_end);
 		iov[6].iov_len = ialen;
-		if (ialen < 0 || (ialen == 0 && opts[-4] == DHCPV6_MSG_REBIND))
+		if (ialen < 0 || (ialen == 0 && (opts[-4] == DHCPV6_MSG_REBIND || opts[-4] == DHCPV6_MSG_CONFIRM)))
 			return;
 	}
 


### PR DESCRIPTION
Hi Steven,

The patches fix two issues regarding status code handling for decline messages and confirm messages without any address options which I noticed during testing.
Could you also have a look at the 2 netifd and the 6rd patches I just submitted on the mailing list ?
The 6rd patch allows the user to select the source IP address based on the tunlink parameter; basically the same logic is already present in the dslite script.
The first netifd patch fixes the removal of dynamic interfaces when a config reload is triggered; the dynamic node version marker is overwritten en interface_set_dynamic was done on an already freed pointer.
Last netifd patch only installs and cleans up the source policy route and other stuff when the prefix address can be installed.

Thx,
Hans
