### PR TITLE
leasefile: do not output expired dhcpv6 leases

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -258,6 +258,8 @@ void dhcpv6_write_statefile(void)
 					for (size_t i = 0; i < addrlen; ++i) {
 						if (addrs[i].prefix > 96)
 							continue;
+						if (c->valid_until <= now)
+							continue;
 
 						addr = addrs[i].addr;
 						if (c->length == 128)


### PR DESCRIPTION
Sometimes ip that is assigned to a host changes, old ip is still kept aroung as 'expired'.
This expired ip gets dumped into leasefile and is read by dnsmasq.
The result is that hotsname is resolved into expired ip and that confuses clients.
This patch prevents expired leases from being written into leasefile.
