### PR TITLE
dhcpv4: implement router configuration option

### DIFF
--- a/README
+++ b/README
@@ -85,6 +85,8 @@ ndp		string	disabled		Neighbor Discovery Proxy
 
 dynamicdhcp	bool	1			dynamically create leases
 						for DHCPv4 and DHCPv6
+router          list    <local address>         Routers to announce
+                                                accepts IPv4 only
 dns		list	<local address>		DNS servers to announce
 						accepts IPv4 and IPv6
 domain		list	<local search domain>	Search domains to announce

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -384,8 +384,11 @@ static void handle_dhcpv4(void *addr, void *data, size_t len,
 					len, search_buf);
 	}
 
-	dhcpv4_put(&reply, &cookie, DHCPV4_OPT_ROUTER, 4, &ifaddr.sin_addr);
-
+	if (iface->dhcpv4_router_cnt == 0)
+		dhcpv4_put(&reply, &cookie, DHCPV4_OPT_ROUTER, 4, &ifaddr.sin_addr);
+	else
+		dhcpv4_put(&reply, &cookie, DHCPV4_OPT_ROUTER,
+				4 * iface->dhcpv4_router_cnt, iface->dhcpv4_router);
 
 
 	if (iface->dhcpv4_dns_cnt == 0)

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -147,6 +147,8 @@ struct interface {
 	// DHCPv4
 	struct in_addr dhcpv4_start;
 	struct in_addr dhcpv4_end;
+	struct in_addr *dhcpv4_router;
+	size_t dhcpv4_router_cnt;
 	struct in_addr *dhcpv4_dns;
 	size_t dhcpv4_dns_cnt;
 	uint32_t dhcpv4_leasetime;


### PR DESCRIPTION
RFC 2132 defines:

3.5. Router Option

   The router option specifies a list of IP addresses for routers on the
   client's subnet.  Routers SHOULD be listed in order of preference.

   The code for the router option is 3.  The minimum length for the
   router option is 4 octets, and the length MUST always be a multiple
   of 4.

```
Code   Len         Address 1               Address 2
```

   +-----+-----+-----+-----+-----+-----+-----+-----+--
   |  3  |  n  |  a1 |  a2 |  a3 |  a4 |  a1 |  a2 |  ...
   +-----+-----+-----+-----+-----+-----+-----+-----+--
