### PR TITLE
Fix IPv6 DNS server adddress selection

### DIFF
--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -263,6 +263,25 @@ ssize_t odhcpd_get_interface_addresses(int ifindex,
 	return ret;
 }
 
+int odhcpd_get_preferred_interface_address(int ifindex, struct in6_addr *addr)
+{
+	struct odhcpd_ipaddr ipaddrs[8];
+	ssize_t ip_cnt = odhcpd_get_interface_addresses(ifindex, ipaddrs, ARRAY_SIZE(ipaddrs));
+	uint32_t preferred = 0;
+	int ret = 0;
+
+	for (ssize_t i = 0; i < ip_cnt; i++) {
+		struct odhcpd_ipaddr *ipaddr = &ipaddrs[i];
+
+		if (ipaddr->preferred > preferred || !preferred) {
+			preferred = ipaddr->preferred;
+			*addr = ipaddr->addr;
+			ret = 1;
+		}
+	}
+
+	return ret;
+}
 
 struct interface* odhcpd_get_interface_by_index(int ifindex)
 {

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -186,6 +186,7 @@ ssize_t odhcpd_send(int socket, struct sockaddr_in6 *dest,
 		const struct interface *iface);
 ssize_t odhcpd_get_interface_addresses(int ifindex,
 		struct odhcpd_ipaddr *addrs, size_t cnt);
+int odhcpd_get_preferred_interface_address(int ifindex, struct in6_addr *addr);
 struct interface* odhcpd_get_interface_by_name(const char *name);
 int odhcpd_get_interface_mtu(const char *ifname);
 int odhcpd_get_mac(const struct interface *iface, uint8_t mac[6]);

--- a/src/router.c
+++ b/src/router.c
@@ -537,7 +537,6 @@ static void forward_router_advertisement(uint8_t *data, size_t len)
 	struct sockaddr_in6 all_nodes = {AF_INET6, 0, 0, ALL_IPV6_NODES, 0};
 	struct iovec iov = {data, len};
 
-	struct odhcpd_ipaddr addr;
 	struct interface *iface;
 	list_for_each_entry(iface, &interfaces, head) {
 		if (iface->ra != RELAYD_RELAY || iface->master)
@@ -550,13 +549,14 @@ static void forward_router_advertisement(uint8_t *data, size_t len)
 		// If we have to rewrite DNS entries
 		if (iface->always_rewrite_dns && dns_ptr && dns_count > 0) {
 			const struct in6_addr *rewrite = iface->dns;
+			struct in6_addr addr;
 			size_t rewrite_cnt = iface->dns_cnt;
 
 			if (rewrite_cnt == 0) {
-				if (odhcpd_get_interface_addresses(iface->ifindex, &addr, 1) < 1)
+				if (odhcpd_get_preferred_interface_address(iface->ifindex, &addr) < 1)
 					continue; // Unable to comply
 
-				rewrite = &addr.addr;
+				rewrite = &addr;
 				rewrite_cnt = 1;
 			}
 


### PR DESCRIPTION
Hi Steven,

Patch fixes the selection of IPv6 DNS address in DHCPv6 and RA overwrite as an address could be selected
with preferred lifetime zero while IPv6 addresses are in use with non zero preferred lifetimes.
Patch now tries to pick the IPv6 address with the longest preferred lifetime.
Fixes also the issue an IPv6 address with preferred lifetime zero could be returned in DHCPv6
DNS server option while an IPv6 address with non zero preferred lifetime is returned as DNS
recursive RA option for the same set of available IPv6 addresses.

Hans
