### PR TITLE
Patches to add flexibility to odhcpd's Route Info Option handling

### DIFF
--- a/README
+++ b/README
@@ -104,6 +104,9 @@ ra_preference	string	medium			Route(r) preference
 		[medium|high|low]
 ra_unreachable  bool    1                       Announce router's unreachable
                                                 routes via Route Info Option
+ra_route        list    <IPv6/bits [low|medium|high]> Announce manually
+                                                configured routes via the RA
+						Route Info Option
 ndproxy_routing	bool	1			Learn routes from NDP
 ndproxy_slave	bool	0			NDProxy external slave
 

--- a/README
+++ b/README
@@ -102,6 +102,8 @@ ra_management	integer	1			RA management mode
 ra_offlink	bool	0			Announce prefixes off-link
 ra_preference	string	medium			Route(r) preference
 		[medium|high|low]
+ra_unreachable  bool    1                       Announce router's unreachable
+                                                routes via Route Info Option
 ndproxy_routing	bool	1			Learn routes from NDP
 ndproxy_slave	bool	0			NDProxy external slave
 

--- a/src/config.c
+++ b/src/config.c
@@ -40,6 +40,7 @@ enum {
 	IFACE_ATTR_RA_OFFLINK,
 	IFACE_ATTR_RA_PREFERENCE,
 	IFACE_ATTR_RA_ADVROUTER,
+	IFACE_ATTR_RA_UNREACHABLE,
 	IFACE_ATTR_PD_MANAGER,
 	IFACE_ATTR_PD_CER,
 	IFACE_ATTR_NDPROXY_ROUTING,
@@ -74,6 +75,7 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_RA_OFFLINK] = { .name = "ra_offlink", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_RA_PREFERENCE] = { .name = "ra_preference", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_RA_ADVROUTER] = { .name = "ra_advrouter", .type = BLOBMSG_TYPE_BOOL },
+	[IFACE_ATTR_RA_UNREACHABLE] = { .name = "ra_unreachable", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_NDPROXY_ROUTING] = { .name = "ndproxy_routing", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_NDPROXY_SLAVE] = { .name = "ndproxy_slave", .type = BLOBMSG_TYPE_BOOL },
 };
@@ -528,6 +530,9 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			goto err;
 	}
 
+	if ((c = tb[IFACE_ATTR_RA_UNREACHABLE]))
+		iface->no_ra_unreachable = !blobmsg_get_bool(c);
+
 	if ((c = tb[IFACE_ATTR_PD_MANAGER]))
 		strncpy(iface->dhcpv6_pd_manager, blobmsg_get_string(c),
 				sizeof(iface->dhcpv6_pd_manager) - 1);
@@ -721,4 +726,3 @@ void odhcpd_run(void)
 	while (!list_empty(&interfaces))
 		close_interface(list_first_entry(&interfaces, struct interface, head));
 }
-

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -101,6 +101,16 @@ struct lease {
 };
 
 
+struct ra_route {
+	uint8_t type;
+	uint8_t len;
+	uint8_t prefix;
+	uint8_t flags;
+	uint32_t lifetime;
+	uint32_t addr[4];
+};
+
+
 struct interface {
 	struct list_head head;
 
@@ -140,6 +150,8 @@ struct interface {
 	bool ra_not_onlink;
 	bool ra_advrouter;
 	bool no_ra_unreachable;
+	struct ra_route *ra_routes;
+	size_t ra_routes_cnt;
 	bool no_dynamic_dhcp;
 
 	int learn_routes;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -139,6 +139,7 @@ struct interface {
 	bool always_rewrite_dns;
 	bool ra_not_onlink;
 	bool ra_advrouter;
+	bool no_ra_unreachable;
 	bool no_dynamic_dhcp;
 
 	int learn_routes;

--- a/src/router.c
+++ b/src/router.c
@@ -384,7 +384,7 @@ static uint64_t send_router_advert(struct interface *iface, const struct in6_add
 		uint32_t addr[4];
 	} routes[RELAYD_MAX_PREFIXES];
 
-	for (ssize_t i = 0; i < ipcnt; ++i) {
+	for (ssize_t i = 0; !iface->no_ra_unreachable && i < ipcnt; ++i) {
 		struct odhcpd_ipaddr *addr = &addrs[i];
 		if (addr->dprefix > 64 || addr->dprefix == 0 ||
 				(addr->dprefix == 64 && addr->prefix == 64)) {


### PR DESCRIPTION
Hi,

While working on a moderately complex IPv6 network setup, I ran into issues with odhcpd's handling of the RA Route Info Option. By default, odhcpd generates a Route Info Option in RAs based on the existence of unreachable routes on the router and this behavior cannot be changed. This pull request implements two new configuration options which make it possible to change odhcpd's behavior somewhat.

The option "ra_unreachable" makes it possible to disable the auto-generated Route Info Option. This is useful, for example, if the router contains multiple unreachable routes or if the route's prefix is different from what should be announced via RA.

The second option "ra_route" makes it possible to manually configure additional routes to be announced in /etc/config/dhcp. This is a per-interface option, different routes can be configured for different interfaces. It's a list option with the following value format:

```
<IPv6/bits [low|medium|high]>
```

The preference field is optional (medium by default). Here's an example:

```
list ra_route "fd00::/16 medium"
```

--Jan
