### PR TITLE
RFC: dhcpv4 support openwrt alias ip addr

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -121,9 +121,11 @@ int setup_dhcpv4_interface(struct interface *iface, bool enable)
 		// Create a range if not specified
 		if (!(iface->dhcpv4_start.s_addr & htonl(0xffff0000)) &&
 				!(iface->dhcpv4_end.s_addr & htonl(0xffff0000))) {
-			struct in_addr addr = ubus_get_address4(iface->ifname);
 
-			struct in_addr mask = ubus_get_mask4(iface->ifname);
+			struct in_addr *saddr = ubus_get_address4(iface->name);
+			struct in_addr addr = { .s_addr = saddr->s_addr } ;
+			struct in_addr *smask = ubus_get_mask4(iface->name);
+			struct in_addr mask = { .s_addr = smask->s_addr } ;
 
 			uint32_t start = ntohl(iface->dhcpv4_start.s_addr);
 			uint32_t end = ntohl(iface->dhcpv4_end.s_addr);
@@ -195,9 +197,11 @@ int setup_dhcpv4_interface(struct interface *iface, bool enable)
 
 		// Clean invalid assignments
 		struct dhcpv4_assignment *a, *n;
+		struct in_addr *smask = ubus_get_mask4(iface->name);
+		struct in_addr mask = { .s_addr = smask->s_addr } ;
 		list_for_each_entry_safe(a, n, &iface->dhcpv4_assignments, head) {
-			if ((htonl(a->addr) & smask->sin_addr.s_addr) !=
-					(iface->dhcpv4_start.s_addr & smask->sin_addr.s_addr)) {
+			if ((htonl(a->addr) & mask.s_addr) !=
+					(iface->dhcpv4_start.s_addr & mask.s_addr)) {
 				list_del(&a->head);
 				free(a);
 			}

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -123,11 +123,12 @@ int setup_dhcpv4_interface(struct interface *iface, bool enable)
 		inet_pton(AF_INET,saddr, &addr);
 		int bits = ubus_get_mask4(iface->name);
 		struct in_addr mask;
-		if (!(bits < -32 || bits > 32)) {
-			mask.s_addr = bits ? htonl(~((1 << (32 - abs(bits))) - 1)) : 0;
-			if (bits < 0)
-				mask.s_addr = ~mask.s_addr;
-		}
+		if (bits < -32 || bits > 32)
+			bits = 0;
+
+		mask.s_addr = bits ? htonl(~((1 << (32 - abs(bits))) - 1)) : 0;
+		if (bits < 0)
+			mask.s_addr = ~mask.s_addr;
 
 
 		// Create a range if not specified

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -119,21 +119,10 @@ int setup_dhcpv4_interface(struct interface *iface, bool enable)
 		}
 
 		// Create a range if not specified
-		//struct ifreq ifreq;
-		//strncpy(ifreq.ifr_name, iface->ifname, sizeof(ifreq.ifr_name));
-
-		//struct sockaddr_in *saddr = (struct sockaddr_in*)&ifreq.ifr_addr;
-		//struct sockaddr_in *smask = (struct sockaddr_in*)&ifreq.ifr_netmask;
-		//if (!(iface->dhcpv4_start.s_addr & htonl(0xffff0000)) &&
-		//		!(iface->dhcpv4_end.s_addr & htonl(0xffff0000)) &&
-		//		!ioctl(sock, SIOCGIFADDR, &ifreq)) {
 		if (!(iface->dhcpv4_start.s_addr & htonl(0xffff0000)) &&
 				!(iface->dhcpv4_end.s_addr & htonl(0xffff0000))) {
-			//struct in_addr addr = saddr->sin_addr;
 			struct in_addr addr = ubus_get_address4(iface->ifname);
 
-			//ioctl(sock, SIOCGIFNETMASK, &ifreq);
-			//struct in_addr mask = smask->sin_addr;
 			struct in_addr mask = ubus_get_mask4(iface->ifname);
 
 			uint32_t start = ntohl(iface->dhcpv4_start.s_addr);

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -119,18 +119,22 @@ int setup_dhcpv4_interface(struct interface *iface, bool enable)
 		}
 
 		// Create a range if not specified
-		struct ifreq ifreq;
-		strncpy(ifreq.ifr_name, iface->ifname, sizeof(ifreq.ifr_name));
+		//struct ifreq ifreq;
+		//strncpy(ifreq.ifr_name, iface->ifname, sizeof(ifreq.ifr_name));
 
-		struct sockaddr_in *saddr = (struct sockaddr_in*)&ifreq.ifr_addr;
-		struct sockaddr_in *smask = (struct sockaddr_in*)&ifreq.ifr_netmask;
+		//struct sockaddr_in *saddr = (struct sockaddr_in*)&ifreq.ifr_addr;
+		//struct sockaddr_in *smask = (struct sockaddr_in*)&ifreq.ifr_netmask;
+		//if (!(iface->dhcpv4_start.s_addr & htonl(0xffff0000)) &&
+		//		!(iface->dhcpv4_end.s_addr & htonl(0xffff0000)) &&
+		//		!ioctl(sock, SIOCGIFADDR, &ifreq)) {
 		if (!(iface->dhcpv4_start.s_addr & htonl(0xffff0000)) &&
-				!(iface->dhcpv4_end.s_addr & htonl(0xffff0000)) &&
-				!ioctl(sock, SIOCGIFADDR, &ifreq)) {
-			struct in_addr addr = saddr->sin_addr;
+				!(iface->dhcpv4_end.s_addr & htonl(0xffff0000))) {
+			//struct in_addr addr = saddr->sin_addr;
+			struct in_addr addr = ubus_get_address4(iface->ifname);
 
-			ioctl(sock, SIOCGIFNETMASK, &ifreq);
-			struct in_addr mask = smask->sin_addr;
+			//ioctl(sock, SIOCGIFNETMASK, &ifreq);
+			//struct in_addr mask = smask->sin_addr;
+			struct in_addr mask = ubus_get_mask4(iface->ifname);
 
 			uint32_t start = ntohl(iface->dhcpv4_start.s_addr);
 			uint32_t end = ntohl(iface->dhcpv4_end.s_addr);

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -209,8 +209,8 @@ int init_ubus(void);
 const char* ubus_get_ifname(const char *name);
 void ubus_apply_network(void);
 bool ubus_has_prefix(const char *name, const char *ifname);
-struct in_addr* ubus_get_address4(const char *name);
-struct in_addr* ubus_get_mask4(const char *name);
+const char* ubus_get_address4(const char *name);
+int ubus_get_mask4(const char *name);
 #endif
 
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -145,6 +145,8 @@ struct interface {
 	int route_preference;
 
 	// DHCPv4
+	struct in_addr dhcpv4_addr;
+	struct in_addr dhcpv4_mask;
 	struct in_addr dhcpv4_start;
 	struct in_addr dhcpv4_end;
 	struct in_addr *dhcpv4_router;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -209,6 +209,8 @@ int init_ubus(void);
 const char* ubus_get_ifname(const char *name);
 void ubus_apply_network(void);
 bool ubus_has_prefix(const char *name, const char *ifname);
+struct in_addr* ubus_get_address4(const char *name);
+struct in_addr* ubus_get_mask4(const char *name);
 #endif
 
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -372,7 +372,7 @@ bool ubus_has_prefix(const char *name, const char *ifname)
 	return false;
 }
 
-struct in_addr ubus_get_address4(const char *name)
+struct in_addr* ubus_get_address4(const char *name)
 {
 	struct blob_attr *c, *cur;
 	unsigned rem;
@@ -397,7 +397,7 @@ struct in_addr ubus_get_address4(const char *name)
 			blobmsg_for_each_attr(d, cur, drem) {
 				struct blob_attr *addr[ADDR_ATTR_MAX];
 				blobmsg_parse(addr_attrs, ADDR_ATTR_MAX, addr, blobmsg_data(d), blobmsg_data_len(d));
-				struct in_addr addr4;
+				struct in_addr *addr4;
 				if (inet_pton(AF_INET, blobmsg_get_string(addr[ADDR_ATTR_ADDRESS]), &addr4) == 1)
 					return addr4;
 			}
@@ -407,7 +407,7 @@ struct in_addr ubus_get_address4(const char *name)
 	return NULL;
 }
 
-struct in_addr ubus_get_mask4(const char *name)
+struct in_addr* ubus_get_mask4(const char *name)
 {
 	struct blob_attr *c, *cur;
 	unsigned rem;
@@ -432,7 +432,7 @@ struct in_addr ubus_get_mask4(const char *name)
 			blobmsg_for_each_attr(d, cur, drem) {
 				struct blob_attr *addr[ADDR_ATTR_MAX];
 				blobmsg_parse(addr_attrs, ADDR_ATTR_MAX, addr, blobmsg_data(d), blobmsg_data_len(d));
-				struct in_addr addr4;
+				struct in_addr *addr4;
 				if (inet_pton(AF_INET, blobmsg_get_string(addr[ADDR_ATTR_MASK]), &addr4) == 1)
 					return addr4;
 			}

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -372,7 +372,7 @@ bool ubus_has_prefix(const char *name, const char *ifname)
 	return false;
 }
 
-struct in_addr* ubus_get_address4(const char *name)
+const char* ubus_get_address4(const char *name)
 {
 	struct blob_attr *c, *cur;
 	unsigned rem;
@@ -395,11 +395,13 @@ struct in_addr* ubus_get_address4(const char *name)
 			struct blob_attr *d;
 			unsigned drem;
 			blobmsg_for_each_attr(d, cur, drem) {
-				struct blob_attr *addr[ADDR_ATTR_MAX];
-				blobmsg_parse(addr_attrs, ADDR_ATTR_MAX, addr, blobmsg_data(d), blobmsg_data_len(d));
-				struct in_addr *addr4;
-				if (inet_pton(AF_INET, blobmsg_get_string(addr[ADDR_ATTR_ADDRESS]), &addr4) == 1)
-					return addr4;
+				struct blob_attr *ccur;
+				unsigned ddrem;
+				struct blob_attr *dict = blobmsg_data(cur);
+				blobmsg_for_each_attr(ccur, dict, ddrem) {
+					if (!strcmp(blobmsg_name(ccur), "address"))
+						return blobmsg_get_string(ccur);
+				}
 			}
 		}
 	}
@@ -407,13 +409,12 @@ struct in_addr* ubus_get_address4(const char *name)
 	return NULL;
 }
 
-struct in_addr* ubus_get_mask4(const char *name)
+int ubus_get_mask4(const char *name)
 {
 	struct blob_attr *c, *cur;
 	unsigned rem;
-
 	if (!dump)
-		return NULL;
+		return 0;
 
 	blobmsg_for_each_attr(c, dump, rem) {
 		struct blob_attr *tb[IFACE_ATTR_MAX];
@@ -430,16 +431,18 @@ struct in_addr* ubus_get_mask4(const char *name)
 			struct blob_attr *d;
 			unsigned drem;
 			blobmsg_for_each_attr(d, cur, drem) {
-				struct blob_attr *addr[ADDR_ATTR_MAX];
-				blobmsg_parse(addr_attrs, ADDR_ATTR_MAX, addr, blobmsg_data(d), blobmsg_data_len(d));
-				struct in_addr *addr4;
-				if (inet_pton(AF_INET, blobmsg_get_string(addr[ADDR_ATTR_MASK]), &addr4) == 1)
-					return addr4;
+				struct blob_attr *ccur;
+				unsigned ddrem;
+				struct blob_attr *dict = blobmsg_data(cur);
+				blobmsg_for_each_attr(ccur, dict, ddrem) {
+					if (!strcmp(blobmsg_name(ccur), "mask"))
+						return blobmsg_get_u32(ccur);
+				}
 			}
 		}
 	}
 
-	return NULL;
+	return 0;
 }
 
 int init_ubus(void)

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -163,6 +163,7 @@ enum {
 	IFACE_ATTR_DATA,
 	IFACE_ATTR_PREFIX,
 	IFACE_ATTR_ADDRESS,
+	IFACE_ATTR_ADDRESS4,
 	IFACE_ATTR_MAX,
 };
 
@@ -173,6 +174,7 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_DATA] = { .name = "data", .type = BLOBMSG_TYPE_TABLE },
 	[IFACE_ATTR_PREFIX] = { .name = "ipv6-prefix", .type = BLOBMSG_TYPE_ARRAY },
 	[IFACE_ATTR_ADDRESS] = { .name = "ipv6-address", .type = BLOBMSG_TYPE_ARRAY },
+	[IFACE_ATTR_ADDRESS4] = { .name = "ipv4-address", .type = BLOBMSG_TYPE_ARRAY },
 };
 
 static void handle_dump(_unused struct ubus_request *req, _unused int type, struct blob_attr *msg)

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -177,17 +177,6 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_ADDRESS4] = { .name = "ipv4-address", .type = BLOBMSG_TYPE_ARRAY },
 };
 
-enum {
-	ADDR_ATTR_ADDRESS,
-	ADDR_ATTR_MASK,
-	ADDR_ATTR_MAX,
-};
-
-static const struct blobmsg_policy addr_attrs[ADDR_ATTR_MAX] = {
-	[ADDR_ATTR_ADDRESS] = { .name = "address", .type = BLOBMSG_TYPE_ARRAY },
-	[ADDR_ATTR_MASK] = { .name = "mask", .type = BLOBMSG_TYPE_INT32 },
-};
-
 static void handle_dump(_unused struct ubus_request *req, _unused int type, struct blob_attr *msg)
 {
 	struct blob_attr *tb[DUMP_ATTR_MAX];

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -361,6 +361,57 @@ bool ubus_has_prefix(const char *name, const char *ifname)
 	return false;
 }
 
+struct in_addr ubus_get_address4(const char *name)
+{
+	struct blob_attr *c;
+	unsigned rem;
+
+	if (!dump)
+		return NULL;
+
+	blobmsg_for_each_attr(c, dump, rem) {
+		struct blob_attr *tb[IFACE_ATTR_MAX];
+		blobmsg_parse(iface_attrs, IFACE_ATTR_MAX, tb, blobmsg_data(c), blobmsg_data_len(c));
+
+		if (!tb[IFACE_ATTR_INTERFACE] || strcmp(name,
+				blobmsg_get_string(tb[IFACE_ATTR_INTERFACE])))
+			continue;
+
+		if (tb[IFACE_ATTR_IFNAME]) {
+			struct in_addr addr4;
+			if (inet_pton(AF_INET, blobmsg_get_string(tb[IFACE_ATTR_ADDRESS4]), &addr4) == 1)
+				return addr4;
+		}
+	}
+
+	return NULL;
+}
+
+struct in_addr ubus_get_mask4(const char *name)
+{
+	struct blob_attr *c;
+	unsigned rem;
+
+	if (!dump)
+		return NULL;
+
+	blobmsg_for_each_attr(c, dump, rem) {
+		struct blob_attr *tb[IFACE_ATTR_MAX];
+		blobmsg_parse(iface_attrs, IFACE_ATTR_MAX, tb, blobmsg_data(c), blobmsg_data_len(c));
+
+		if (!tb[IFACE_ATTR_INTERFACE] || strcmp(name,
+				blobmsg_get_string(tb[IFACE_ATTR_INTERFACE])))
+			continue;
+
+		if (tb[IFACE_ATTR_IFNAME]) {
+			struct in_addr mask4;
+			if (inet_pton(AF_INET, blobmsg_get_string(tb[IFACE_ATTR_MASK4]), &mask4) == 1)
+				return mask4;
+		}
+	}
+
+	return NULL;
+}
 
 int init_ubus(void)
 {


### PR DESCRIPTION
Alias IP addr config in openwrt:
network.lan=interface
network.lan.proto=static
network.lan.ifname=eth0
network.lan.ipaddr=10.31.0.76
network.lan.netmask=255.255.0.0
network.landhcp=interface
network.landhcp.proto=static
network.landhcp.ifname=@lan
network.landhcp.ipaddr=10.230.6.97
network.landhcp.netmask=255.255.255.224

The lan.ippaddr is for mesh-routing.
The landhcp.ippaddr is the IP Range for Clients.

Alias IP dhcp config in openwrt:
dhcp.lan=dhcp
dhcp.lan.ignore=0
dhcp.lan.interface=lan
dhcp.landhcp=dhcp
dhcp.landhcp.ignore=0
dhcp.landhcp.interface=landhcp
