### PR TITLE
Don't overflow router lifetime

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -292,10 +292,13 @@ static uint64_t send_router_advert(struct interface *iface, const struct in6_add
 				minvalid > 1000LL * TIME_LEFT(addr->valid, now))
 			minvalid = 1000LL * TIME_LEFT(addr->valid, now);
 
+		uint32_t this_lifetime = TIME_LEFT(addr->valid, now);
+		if (this_lifetime > UINT16_MAX)
+			this_lifetime = UINT16_MAX;
 		if (((addr->addr.s6_addr[0] & 0xfe) != 0xfc || iface->default_router)
 				&& adv.h.nd_ra_router_lifetime
-				&& ntohs(adv.h.nd_ra_router_lifetime) < TIME_LEFT(addr->valid, now))
-			adv.h.nd_ra_router_lifetime = htons(TIME_LEFT(addr->valid, now));
+				&& ntohs(adv.h.nd_ra_router_lifetime) < this_lifetime)
+			adv.h.nd_ra_router_lifetime = htons(this_lifetime);
 
 		odhcpd_bmemcpy(&p->nd_opt_pi_prefix, &addr->addr,
 				(iface->ra_advrouter) ? 128 : addr->prefix);


### PR DESCRIPTION
This also avoids advertising an incorrectly short router lifetime when
a prefix lifetime is greater than 2 *\* 16, due to the truncation to
16 bits.
