### PR TITLE
router: reduce dns lifetime to 2x maximum interval

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -436,7 +436,7 @@ static uint64_t send_router_advert(struct interface *iface, const struct in6_add
 
 	minival = (maxival * 3) / 4;
 
-	search->lifetime = htonl(maxival / 100);
+	search->lifetime = htonl(maxival * 2 / 1000);
 	dns.lifetime = search->lifetime;
 
 	odhcpd_urandom(&msecs, sizeof(msecs));


### PR DESCRIPTION
RFC6106 states that the lifetime of the RDNSS and DNSSL options
SHOULD be bounded as follows:
MaxRtrAdvInterval <= Lifetime <= 2*MaxRtrAdvInterval.

Choose the upper end of this interval.
