### PR TITLE
router: skip parse_routes when ra_default > 1

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -257,10 +257,10 @@ static uint64_t send_router_advert(struct interface *iface, const struct in6_add
 		memcpy(addrs, iface->ia_addr, ipcnt * sizeof(*addrs));
 
 		// Check default route
-		if (parse_routes(addrs, ipcnt))
-			adv.h.nd_ra_router_lifetime = htons(1);
 		if (iface->default_router > 1)
 			adv.h.nd_ra_router_lifetime = htons(iface->default_router);
+		else if (parse_routes(addrs, ipcnt))
+			adv.h.nd_ra_router_lifetime = htons(1);
 	}
 
 	// Construct Prefix Information options


### PR DESCRIPTION
It does not make sense to scan the entire routing table if the decision
will be overridden afterwards.

This makes it possible to use odhcpd on a router with full BGP table, by setting ra_default to 2. Without this change, odhcpd is constantly busy reading /proc/net/ipv6_route and doesn't respond to router sollications in time.
