### PR TITLE
Infinite leasetime support and several bugfixes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -218,9 +218,10 @@ static void set_config(struct uci_section *s)
 }
 
 static double parse_leasetime(struct blob_attr *c) {
-	char *val = blobmsg_get_string(c), *endptr;
-	double time = strtod(val, &endptr);
-	if (time && endptr[0]) {
+	char *val = blobmsg_get_string(c), *endptr = NULL;
+	double time = strcmp(val, "infinite") ? strtod(val, &endptr) : UINT32_MAX;
+
+	if (time && endptr && endptr[0]) {
 		if (endptr[0] == 's')
 			time *= 1;
 		else if (endptr[0] == 'm')

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -247,7 +247,8 @@ void dhcpv6_write_statefile(void)
 							iface->ifname, duidbuf, ntohl(c->iaid),
 							(c->hostname ? c->hostname : "-"),
 							(unsigned)(c->valid_until > now ?
-									(c->valid_until - now + wall_time) : 0),
+									(c->valid_until - now + wall_time) :
+									(INFINITE_VALID(c->valid_until) ? INT32_MAX: 0)),
 							c->assigned, (unsigned)c->length);
 
 					struct in6_addr addr;
@@ -309,7 +310,8 @@ void dhcpv6_write_statefile(void)
 							iface->ifname, duidbuf,
 							(c->hostname ? c->hostname : "-"),
 							(unsigned)(c->valid_until > now ?
-									(c->valid_until - now + wall_time) : 0),
+									(c->valid_until - now + wall_time) :
+									(INFINITE_VALID(c->valid_until) ? INT32_MAX: 0)),
 							c->addr);
 
 					struct in_addr addr = {htonl(c->addr)};

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -44,6 +44,8 @@
 #define RELAYD_BUFFER_SIZE 8192
 #define RELAYD_MAX_PREFIXES 8
 
+#define INFINITE_VALID(x) ((x) == 0)
+
 #define _unused __attribute__((unused))
 #define _packed __attribute__((packed))
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -34,7 +34,7 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _unused struct ubus_ob
 
 		struct dhcpv4_assignment *lease;
 		list_for_each_entry(lease, &iface->dhcpv4_assignments, head) {
-			if (lease->valid_until < now)
+			if (!INFINITE_VALID(lease->valid_until) && lease->valid_until < now)
 				continue;
 
 			void *l = blobmsg_open_table(&b, NULL);
@@ -50,7 +50,8 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _unused struct ubus_ob
 			inet_ntop(AF_INET, &addr, buf, INET_ADDRSTRLEN);
 			blobmsg_add_string_buffer(&b);
 
-			blobmsg_add_u32(&b, "valid", now - lease->valid_until);
+			blobmsg_add_u32(&b, "valid", INFINITE_VALID(lease->valid_until) ?
+						INT32_MAX : (uint32_t)(lease->valid_until - now));
 
 			blobmsg_close_table(&b, l);
 		}
@@ -83,7 +84,7 @@ static int handle_dhcpv6_leases(_unused struct ubus_context *ctx, _unused struct
 
 		struct dhcpv6_assignment *lease;
 		list_for_each_entry(lease, &iface->ia_assignments, head) {
-			if (lease->valid_until < now)
+			if (!INFINITE_VALID(lease->valid_until) && lease->valid_until < now)
 				continue;
 
 			void *l = blobmsg_open_table(&b, NULL);
@@ -115,7 +116,8 @@ static int handle_dhcpv6_leases(_unused struct ubus_context *ctx, _unused struct
 			}
 			blobmsg_close_table(&b, m);
 
-			blobmsg_add_u32(&b, "valid", now - lease->valid_until);
+			blobmsg_add_u32(&b, "valid", INFINITE_VALID(lease->valid_until) ?
+						INT32_MAX : (uint32_t)(lease->valid_until - now));
 
 			blobmsg_close_table(&b, l);
 		}


### PR DESCRIPTION
PR has the following commits
-Support for infinite leasetime per dhcp and host section; fixes broken IPv6 connectivity in case infinite is specified as a leasetime value for a dhcp pool as odhcpd was considering this as an invalid value and closed the interface. This particular problem pops up if dnsmasq is used as DHCPv4 server and one of the pools is assigned an infinite leasetime.
-Support for leasetime requested by DHCPv4 clients
-Fixes negative valid number being displayed in ubus dhcp ipv4leases
-Keeps DHCPv4 assignment lifetime in sync with DHCP client leasetime
-Displays infinite as INT32_MAX in odhcpd hosts file