### PR TITLE
dhcpv6: allow creating new bindings on REBIND

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1051,7 +1051,9 @@ ssize_t dhcpv6_handle_ia(uint8_t *buf, size_t buflen, struct interface *iface,
 		uint16_t status = DHCPV6_STATUS_OK;
 		if (a && a->managed_size < 0) {
 			return -1;
-		} else if (hdr->msg_type == DHCPV6_MSG_SOLICIT || hdr->msg_type == DHCPV6_MSG_REQUEST) {
+		} else if (hdr->msg_type == DHCPV6_MSG_SOLICIT ||
+				hdr->msg_type == DHCPV6_MSG_REQUEST ||
+				hdr->msg_type == DHCPV6_MSG_REBIND) {
 			bool assigned = !!a;
 
 			if (!a && !iface->no_dynamic_dhcp) { // Create new binding
@@ -1135,8 +1137,7 @@ ssize_t dhcpv6_handle_ia(uint8_t *buf, size_t buflen, struct interface *iface,
 			if (!a && hdr->msg_type != DHCPV6_MSG_REBIND) {
 				status = DHCPV6_STATUS_NOBINDING;
 				ia_response_len = append_reply(buf, buflen, status, ia, a, iface, false);
-			} else if (hdr->msg_type == DHCPV6_MSG_RENEW ||
-					hdr->msg_type == DHCPV6_MSG_REBIND) {
+			} else if (hdr->msg_type == DHCPV6_MSG_RENEW) {
 				ia_response_len = append_reply(buf, buflen, status, ia, a, iface, false);
 				if (a)
 					apply_lease(iface, a, true);


### PR DESCRIPTION
There might be unassigned IAs among the options the client sends when it
issues a REBIND. In fact, that's how the ISC dhclient reqests new IA_PDs
to be assigned. However, odhcpd would just return the IA_PDs back
without assigning a prefix:

  $ dhclient -6 -d -lf $PWD/leases eth0 -N
  XMT: Forming Solicit, 0 ms elapsed.
  XMT:  X-- IA_NA 00:3b:dd:9d
  RCV: Advertise message on eth2 from fe80::5054:ff:feba:444e.
  RCV:  X-- IA_NA 00:3b:dd:9d
  ^C
  $ dhclient -6 -d -lf $PWD/leases eth0 -N -P
  XMT: Forming Rebind, 0 ms elapsed.
  XMT:  X-- IA_NA 00:3b:dd:9d
  XMT:  X-- IA_PD 00:3b:dd:9d
  RCV: Reply message on eth2 from fe80::5054:ff:feba:444e.
  RCV:  X-- IA_NA 00:3b:dd:9d
  RCV:  X-- IA_PD 00:3b:dd:9d
  RCV:  | !-- Status code of no prefix, IA_PD discarded.

That is neither too useful, nor consistent with what the ISC dhcpcd does,
nor does it seem correct. Notably, it breaks NetworkManager's IPv6
connection sharing that utilizes the ISC dhclient and needs to request the
prefixes as-needed on networks with OpenWRT.

The attached patch moves the REBIND handling to the branch that is able
to add new bindings. It then, perhaps unnecessarily, also allows
obtaining new IA_NAs this way.

(While the patch fixes the issue for me, I'm not too familiar with the
odhcpd code base, so a careful review is needed.)