### PR TITLE
odhcpd: change ignore interface tag from ignore to ignore6

### DIFF
--- a/README
+++ b/README
@@ -70,7 +70,7 @@ Option		Type	Default			Description
 interface	string	<name of UCI section>	logical OpenWrt interface
 ifname		string	<resolved from logical>	physical network interface
 networkid	string	same as ifname		compat. alias for ifname
-ignore		bool	0			ignore this interface
+ignore6		bool	0			ignore this interface
 master		bool	0			is a master interface
 						for relaying
 

--- a/src/config.c
+++ b/src/config.c
@@ -53,7 +53,7 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_IFNAME] = { .name = "ifname", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_NETWORKID] = { .name = "networkid", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_DYNAMICDHCP] = { .name = "dynamicdhcp", .type = BLOBMSG_TYPE_BOOL },
-	[IFACE_ATTR_IGNORE] = { .name = "ignore", .type = BLOBMSG_TYPE_BOOL },
+	[IFACE_ATTR_IGNORE] = { .name = "ignore6", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_LEASETIME] = { .name = "leasetime", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_START] = { .name = "start", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_LIMIT] = { .name = "limit", .type = BLOBMSG_TYPE_INT32 },


### PR DESCRIPTION
There are network setup where it would be required to turn off dhcpv4
and have dhcpv6 (and all the address autoconfiguration) enabled
An example is a full static ipv4 dual stack network, also an ipv4
relayed bridge with ipv6 relay. Having the tag "ignore" used by both
dnsmasq and odhcpd as interface ignore tag prevents the configuration
of such networks

Signed-off-by: Antonio Silverio <menion@gmail.com>