### PR TITLE
dhcpv6: fix ivalid json

### DIFF
--- a/src/ubus.c
+++ b/src/ubus.c
@@ -80,7 +80,7 @@ static void dhcpv6_blobmsg_ia_addr(struct in6_addr *addr, int prefix, uint32_t p
 					uint32_t valid, _unused void *arg)
 {
 	void *a	= blobmsg_open_table(&b, NULL);
-	char *buf = blobmsg_alloc_string_buffer(&b, NULL, INET6_ADDRSTRLEN);
+	char *buf = blobmsg_alloc_string_buffer(&b, "address", INET6_ADDRSTRLEN);
 
 	inet_ntop(AF_INET6, addr, buf, INET6_ADDRSTRLEN);
 	blobmsg_add_string_buffer(&b);


### PR DESCRIPTION
```
"ipv6-prefix": [
	{
		"<some ipv6 address>",
		"preferred-lifetime": 37979,
		"valid-lifetime": 48779,
		"prefix-length": 63
	}
],
```

Just wanted to point out that the ubus call "ubus call dhcp ipv6leases" does not return a valid JSON. The ipv6 address is missing the key name.

I'm not sure what the key name should be so for now I set it to "address".
Please can somebody take a look at this.

Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>