### PR TITLE
netlink: trigger address list refresh on preference change

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -160,6 +160,7 @@ static void refresh_iface_addr6(struct netevent_handler_info *event_info)
 	struct odhcpd_ipaddr *addr = NULL;
 	struct interface *iface = event_info->iface;
 	ssize_t len = netlink_get_interface_addrs(iface->ifindex, true, &addr);
+	time_t now = odhcpd_time();
 
 	if (len < 0)
 		return;
@@ -168,6 +169,7 @@ static void refresh_iface_addr6(struct netevent_handler_info *event_info)
 	for (ssize_t i = 0; !change && i < len; ++i)
 		if (!IN6_ARE_ADDR_EQUAL(&addr[i].addr.in6, &iface->addr6[i].addr.in6) ||
 				(addr[i].preferred > 0) != (iface->addr6[i].preferred > 0) ||
+				(addr[i].preferred > (uint32_t) now) != (iface->addr6[i].preferred > (uint32_t) now) ||
 				addr[i].valid < iface->addr6[i].valid ||
 				addr[i].preferred < iface->addr6[i].preferred)
 			change = true;


### PR DESCRIPTION
Currently we fire an address list change event in following cases:

1. address changed
2. preferred time changed to/from forever
3. valid period shortened
4. preferred period shortened

However there are common cases where addresses become deprecated and then preferred again. odhcpd will catch the former event (by case 4) and sets border->assigned to 0, but will not set it back to normal as it could not get notified about the latter event. Thus all PD allocations fail due to no prefix being available.

The cases can be as common as a redial on PPP interfaces, or a manual reconnection on the wan6 interface.

This commit adds another case for firing address list change event: address became preferred from deprecated, or the other way round. The former will solve the problem aforementioned, and the latter is a subset of existing case 4 so there should not be any regression.