### PR TITLE
dhcpv6: add setting to choose IA_NA, IA_PD or both

### DIFF
--- a/README
+++ b/README
@@ -98,6 +98,10 @@ dhcpv6_assignall	bool	1			Assign all viable DHCPv6 addresses
 							in statefull mode; if disabled
 							only the DHCPv6 address having the
 							longest preferred lifetime is assigned
+dhcpv6_na		bool	1			DHCPv6 stateful addressing hands out IA_NA -
+								Internet Address - Network Address
+dhcpv6_pd		bool	1			DHCPv6 stateful addressing hands out IA_PD -
+								Internet Address - Prefix Delegation
 router			list    <local address>		Routers to announce
 							accepts IPv4 only
 dns			list	<local address>		DNS servers to announce

--- a/src/config.c
+++ b/src/config.c
@@ -45,6 +45,8 @@ enum {
 	IFACE_ATTR_DHCPV4_FORCERECONF,
 	IFACE_ATTR_DHCPV6_RAW,
 	IFACE_ATTR_DHCPV6_ASSIGNALL,
+	IFACE_ATTR_DHCPV6_PD,
+	IFACE_ATTR_DHCPV6_NA,
 	IFACE_ATTR_RA_DEFAULT,
 	IFACE_ATTR_RA_MANAGEMENT,
 	IFACE_ATTR_RA_OFFLINK,
@@ -89,6 +91,8 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_DHCPV4_FORCERECONF] = { .name = "dhcpv4_forcereconf", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_DHCPV6_RAW] = { .name = "dhcpv6_raw", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_DHCPV6_ASSIGNALL] = { .name ="dhcpv6_assignall", .type = BLOBMSG_TYPE_BOOL },
+	[IFACE_ATTR_DHCPV6_PD] = { .name = "dhcpv6_pd", .type = BLOBMSG_TYPE_BOOL },
+	[IFACE_ATTR_DHCPV6_NA] = { .name = "dhcpv6_na", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_PD_MANAGER] = { .name = "pd_manager", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_PD_CER] = { .name = "pd_cer", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_RA_DEFAULT] = { .name = "ra_default", .type = BLOBMSG_TYPE_INT32 },
@@ -216,6 +220,8 @@ static void set_interface_defaults(struct interface *iface)
 	iface->learn_routes = 1;
 	iface->dhcpv4_leasetime = 43200;
 	iface->dhcpv6_assignall = true;
+	iface->dhcpv6_pd = true;
+	iface->dhcpv6_na = true;
 	iface->ra_managed = RA_MANAGED_MFLAG;
 	iface->ra_maxinterval = 600;
 	iface->ra_mininterval = iface->ra_maxinterval/3;
@@ -650,6 +656,12 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_DHCPV6_ASSIGNALL]))
 		iface->dhcpv6_assignall = blobmsg_get_bool(c);
+
+	if ((c = tb[IFACE_ATTR_DHCPV6_PD]))
+		iface->dhcpv6_pd = blobmsg_get_bool(c);
+
+	if ((c = tb[IFACE_ATTR_DHCPV6_NA]))
+		iface->dhcpv6_na = blobmsg_get_bool(c);
 
 	if ((c = tb[IFACE_ATTR_RA_DEFAULT]))
 		iface->default_router = blobmsg_get_u32(c);

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1262,7 +1262,7 @@ ssize_t dhcpv6_handle_ia(uint8_t *buf, size_t buflen, struct interface *iface,
 				(hdr->msg_type == DHCPV6_MSG_REBIND && !a)) {
 			bool assigned = !!a;
 
-			if (!a && !iface->no_dynamic_dhcp) {
+			if (!a && !iface->no_dynamic_dhcp && (iface->dhcpv6_pd || iface->dhcpv6_na)) {
 				/* Create new binding */
 				a = calloc(1, sizeof(*a) + clid_len);
 				if (a) {
@@ -1282,10 +1282,10 @@ ssize_t dhcpv6_handle_ia(uint8_t *buf, size_t buflen, struct interface *iface,
 						odhcpd_urandom(a->key, sizeof(a->key));
 					memcpy(a->clid_data, clid_data, clid_len);
 
-					if (is_pd)
+					if (is_pd && iface->dhcpv6_pd)
 						while (!(assigned = assign_pd(iface, a)) &&
 								!a->managed_size && ++a->length <= 64);
-					else
+					else if (is_na && iface->dhcpv6_na)
 						assigned = assign_na(iface, a);
 
 					if (a->managed_size && !assigned)

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -236,6 +236,8 @@ struct interface {
 	void *dhcpv6_raw;
 	size_t dhcpv6_raw_len;
 	bool dhcpv6_assignall;
+	bool dhcpv6_pd;
+	bool dhcpv6_na;
 
 	char *upstream;
 	size_t upstream_len;


### PR DESCRIPTION
This commit implements feature request #111 
Adds the config options to set if DHCPv6 'stateful addresing' hands out
IA_NA (Internet Address - Network Address), IA_PD (Internet Address -
Prefix Delegation), both or none.

The config options are 'dhcpv6_pd' and 'dhcpv6_na' of type boolean.

The default setting for both options is 'true'.

Codes for NoAddrsAvail or NoPrefixAvail are returned if IA_NA or IA_PD are set not to be handed out.

Signed-off-by: Matija Amidzic <matija.amidzic@sartura.hr>