### PR TITLE
Support ra_lifetime=0

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -354,7 +354,7 @@ static uint32_t calc_ra_lifetime(struct interface *iface, uint32_t maxival)
 
 	if (iface->ra_lifetime >= 0) {
 		lifetime = iface->ra_lifetime;
-		if (lifetime < maxival)
+		if (lifetime > 0 && lifetime < maxival)
 			lifetime = maxival;
 		else if (lifetime > 9000)
 			lifetime = 9000;


### PR DESCRIPTION
The value 0 has the special meaning of not being a default router. This is useful to only advertise prefixes or DNS settings without being a real router.