### PR TITLE
router: close socket upon NETEV_IFINDEX_CHANGE

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -229,6 +229,11 @@ static void router_netevent_cb(unsigned long event, struct netevent_handler_info
 	struct interface *iface;
 
 	switch (event) {
+	case NETEV_IFINDEX_CHANGE:
+		iface = info->iface;
+		if (iface && iface->router_event.uloop.fd >= 0)
+			close(iface->router_event.uloop.fd);
+		break;
 	case NETEV_ROUTE6_ADD:
 	case NETEV_ROUTE6_DEL:
 		if (info->rt.dst_len)


### PR DESCRIPTION
Make sure the socket is closed in a case where the bridge goes down
as a result of NO-CARRIER on the bridge. If not present Router Discovery and Router Advertisement will break permanently after the bridge went down.

Related to  https://github.com/openwrt/odhcpd/issues/135

Signed-off-by: Koen Aerts <aertskoen5@gmail.com>