### PR TITLE
fix lingering uloop socket descriptor in close socket upon NETEV_IFINDEX_CHANGE code path

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -229,6 +229,11 @@ static void router_netevent_cb(unsigned long event, struct netevent_handler_info
 	struct interface *iface;
 
 	switch (event) {
+	case NETEV_IFINDEX_CHANGE:
+		iface = info->iface;
+		if (iface && iface->router_event.uloop.fd >= 0)
+			close(iface->router_event.uloop.fd);
+		break;
 	case NETEV_ROUTE6_ADD:
 	case NETEV_ROUTE6_DEL:
 		if (info->rt.dst_len)

--- a/src/router.c
+++ b/src/router.c
@@ -231,8 +231,10 @@ static void router_netevent_cb(unsigned long event, struct netevent_handler_info
 	switch (event) {
 	case NETEV_IFINDEX_CHANGE:
 		iface = info->iface;
-		if (iface && iface->router_event.uloop.fd >= 0)
+		if (iface && iface->router_event.uloop.fd >= 0) {
 			close(iface->router_event.uloop.fd);
+			iface->router_event.uloop.fd = -1;
+		}
 		break;
 	case NETEV_ROUTE6_ADD:
 	case NETEV_ROUTE6_DEL:

--- a/src/router.c
+++ b/src/router.c
@@ -232,6 +232,8 @@ static void router_netevent_cb(unsigned long event, struct netevent_handler_info
 	case NETEV_IFINDEX_CHANGE:
 		iface = info->iface;
 		if (iface && iface->router_event.uloop.fd >= 0) {
+			if (iface->router_event.uloop.registered)
+				uloop_fd_delete(&iface->router_event.uloop);
 			close(iface->router_event.uloop.fd);
 			iface->router_event.uloop.fd = -1;
 		}


### PR DESCRIPTION
make sure the raw socket is removed from the uloop file descriptor list before the
    socket is closed. As introduced in https://github.com/openwrt/odhcpd/commit/000182fe4f94a5a6ec139456a2b74f0cdea13b9c
    
    Related to  https://github.com/openwrt/odhcpd/issues/135
