### PR TITLE
router: close socket upon NETEV_IFINDEX_CHANGE fixed

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -232,6 +232,8 @@ static void router_netevent_cb(unsigned long event, struct netevent_handler_info
 	case NETEV_IFINDEX_CHANGE:
 		iface = info->iface;
 		if (iface && iface->router_event.uloop.fd >= 0) {
+			if (iface->router_event.uloop.registered)
+				uloop_fd_delete(&iface->router_event.uloop);
 			close(iface->router_event.uloop.fd);
 			iface->router_event.uloop.fd = -1;
 		}


### PR DESCRIPTION
make sure the raw socket is removed from the uloop file descriptor list before the
socket is closed. As introduced in https://github.com/openwrt/odhcpd/commit/000182fe4f94a5a6ec139456a2b74f0cdea13b9c

Related to  https://github.com/openwrt/odhcpd/issues/135

Signed-off-by: Koen Aerts <aertskoen5@gmail.com>