### PR TITLE
dhcpv6: retry failed PD assignments on addrlist change

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -700,7 +700,7 @@ static void handle_addrlist_change(struct netevent_handler_info *info)
 				c->managed_size)
 			continue;
 
-		if (c->length < 128 && c->assigned >= border->assigned && c != border)
+		if (c->length < 128 && (c->assigned == 0 || c->assigned >= border->assigned) && c != border)
 			list_move(&c->head, &reassign);
 		else if (c != border && (c->flags & OAF_BOUND))
 			apply_lease(iface, c, true);


### PR DESCRIPTION
I found that odhcpd stopped distributing prefixes to clients when IPv6 addresses on the serving interface were removed and added again. This happens pretty frequently for me, as my IPv6 addresses come solely from PD by ISP and ISP kills the PPPoE WAN session every two days. Addresses on LAN will absolutely be cleared when WAN goes down.

This change fixes the issue for me but I'm not sure whether this is the best way to do it. I've put my analysis into the commit message, please have a look. Thanks!