### PR TITLE
Write leases then atomically rename lease file

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -306,10 +306,14 @@ void dhcpv6_ia_write_statefile(void)
 	md5_begin(&ctxt.md5);
 
 	if (config.dhcp_statefile) {
+		unsigned tmp_statefile_strlen = strlen(config.dhcp_statefile)+strlen(".tmp")+1;
+		char* tmp_statefile = alloca(tmp_statefile_strlen);
 		time_t now = odhcpd_time(), wall_time = time(NULL);
-		int fd = open(config.dhcp_statefile, O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
+		int fd;
 		char leasebuf[512];
-
+		snprintf(tmp_statefile, tmp_statefile_strlen,"%s.tmp", config.dhcp_statefile);
+		
+		fd = open(tmp_statefile, O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
 		if (fd < 0)
 			return;
 		int ret;
@@ -410,6 +414,7 @@ void dhcpv6_ia_write_statefile(void)
 		}
 
 		fclose(ctxt.fp);
+		rename(tmp_statefile, config.dhcp_statefile);
 	}
 
 	uint8_t newmd5[16];


### PR DESCRIPTION
### Problem

Consumers of this file need a consistent view.

For example, if /usr/lib/unbound/odhcpd.sh reads a partial file, it may remove many addresses from unbound DNS. Potentially it might also give an incomplete address entry to unbound.

### Solution

Write to a temporary file in the same directory (so hopefully same filesystem). Then use the POSIX rename function to atomically replace the lease file when done.

### Testing

This compiles, but not sure how to build an opkg to test. I have openwrt checked out, but I only build odhcpd-ipv6only for some reason and I need the full build to test on my network. Would love help!


