### PR TITLE
dhcpv6: fix size_t fields in syslog format

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -253,7 +253,7 @@ static int send_reply(_unused const void *buf, size_t len,
 	struct dhcpv4_msg_data *reply = opaque;
 
 	if (len > reply->maxsize) {
-		syslog(LOG_ERR, "4o6: reply too large, %u > %u", len, reply->maxsize);
+		syslog(LOG_ERR, "4o6: reply too large, %zu > %zu", len, reply->maxsize);
 		reply->len = -1;
 	} else {
 		memcpy(reply->msg, buf, len);


### PR DESCRIPTION
Signed-off-by: Mikael Magnusson <mikma@users.sourceforge.net>