### PR TITLE
config: add an option to indicate the availability of dns server on interfaces

### DIFF
--- a/README
+++ b/README
@@ -103,6 +103,8 @@ router			list    <local address>		Routers to announce
 							accepts IPv4 only
 dns			list	<local address>		DNS servers to announce
 							accepts IPv4 and IPv6
+dns_service		bool	1			Announce the address of interface as DNS service
+							if the list of dns is empty
 domain			list	<local search domain>	Search domains to announce
 
 leasetime		string	12h			DHCPv4 address leasetime

--- a/src/config.c
+++ b/src/config.c
@@ -53,6 +53,7 @@ enum {
 	IFACE_ATTR_NDP,
 	IFACE_ATTR_ROUTER,
 	IFACE_ATTR_DNS,
+	IFACE_ATTR_DNS_SERVICE,
 	IFACE_ATTR_DOMAIN,
 	IFACE_ATTR_FILTER_CLASS,
 	IFACE_ATTR_DHCPV4_FORCERECONF,
@@ -100,6 +101,7 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_NDP] = { .name = "ndp", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_ROUTER] = { .name = "router", .type = BLOBMSG_TYPE_ARRAY },
 	[IFACE_ATTR_DNS] = { .name = "dns", .type = BLOBMSG_TYPE_ARRAY },
+	[IFACE_ATTR_DNS_SERVICE] = { .name = "dns_service", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_DOMAIN] = { .name = "domain", .type = BLOBMSG_TYPE_ARRAY },
 	[IFACE_ATTR_FILTER_CLASS] = { .name = "filter_class", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_DHCPV4_FORCERECONF] = { .name = "dhcpv4_forcereconf", .type = BLOBMSG_TYPE_BOOL },
@@ -235,6 +237,7 @@ static void set_interface_defaults(struct interface *iface)
 	iface->dhcpv6_assignall = true;
 	iface->dhcpv6_pd = true;
 	iface->dhcpv6_na = true;
+	iface->dns_service = true;
 	iface->ra_flags = ND_RA_FLAG_OTHER;
 	iface->ra_slaac = true;
 	iface->ra_maxinterval = 600;
@@ -684,6 +687,9 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 				goto err;
 		}
 	}
+
+	if ((c = tb[IFACE_ATTR_DNS_SERVICE]))
+		iface->dns_service = blobmsg_get_bool(c);
 
 	if ((c = tb[IFACE_ATTR_DOMAIN])) {
 		struct blob_attr *cur;

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -842,9 +842,10 @@ void dhcpv4_handle_msg(void *addr, void *data, size_t len,
 				4 * iface->dhcpv4_router_cnt, iface->dhcpv4_router);
 
 
-	if (iface->dhcpv4_dns_cnt == 0)
-		dhcpv4_put(&reply, &cookie, DHCPV4_OPT_DNSSERVER, 4, &iface->dhcpv4_local);
-	else
+	if (iface->dhcpv4_dns_cnt == 0) {
+		if (iface->dns_service)
+			dhcpv4_put(&reply, &cookie, DHCPV4_OPT_DNSSERVER, 4, &iface->dhcpv4_local);
+	} else
 		dhcpv4_put(&reply, &cookie, DHCPV4_OPT_DNSSERVER,
 				4 * iface->dhcpv4_dns_cnt, iface->dhcpv4_dns);
 

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -253,6 +253,9 @@ int odhcpd_get_interface_dns_addr(const struct interface *iface, struct in6_addr
 	time_t now = odhcpd_time();
 	ssize_t m = -1;
 
+	if (!iface->dns_service)
+		return -1;
+
 	for (size_t i = 0; i < iface->addr6_len; ++i) {
 		if (iface->addr6[i].valid <= (uint32_t)now)
 			continue;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -253,6 +253,7 @@ struct interface {
 	bool master;
 	bool ignore;
 	bool always_rewrite_dns;
+	bool dns_service;
 
 	// NDP
 	int learn_routes;


### PR DESCRIPTION
In some cases the IPv6 dns server is not available on the LAN interface, thus we don't want ra/dhcpv6 server to announce the ipv6 address as dns to clients.

Currently, the ra server has 'ra_dns' option to disable the function, but there is no option for dhcpv6. I think a new option 'dnsvalid' to indicate the availability of dns server on specific interface would be better. (I'm not sure if the phrase 'dnsvalid' is suitable for this purpose.)

Thanks!
