### PR TITLE
ubus: add add_lease method

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -144,17 +144,7 @@ const struct uci_blob_param_list interface_attr_list = {
 	.info = iface_attr_info,
 };
 
-enum {
-	LEASE_ATTR_IP,
-	LEASE_ATTR_MAC,
-	LEASE_ATTR_DUID,
-	LEASE_ATTR_HOSTID,
-	LEASE_ATTR_LEASETIME,
-	LEASE_ATTR_NAME,
-	LEASE_ATTR_MAX
-};
-
-static const struct blobmsg_policy lease_attrs[LEASE_ATTR_MAX] = {
+const struct blobmsg_policy lease_attrs[LEASE_ATTR_MAX] = {
 	[LEASE_ATTR_IP] = { .name = "ip", .type = BLOBMSG_TYPE_STRING },
 	[LEASE_ATTR_MAC] = { .name = "mac", .type = BLOBMSG_TYPE_STRING },
 	[LEASE_ATTR_DUID] = { .name = "duid", .type = BLOBMSG_TYPE_STRING },
@@ -387,16 +377,15 @@ static void free_lease(struct lease *l)
 	free(l);
 }
 
-static int set_lease(struct uci_section *s)
+
+int set_lease_from_blobmsg(struct blob_attr *ba)
 {
 	struct blob_attr *tb[LEASE_ATTR_MAX], *c;
 	struct lease *l;
 	size_t duidlen = 0;
 	uint8_t *duid;
 
-	blob_buf_init(&b, 0);
-	uci_to_blob(&b, s, &lease_attr_list);
-	blobmsg_parse(lease_attrs, LEASE_ATTR_MAX, tb, blob_data(b.head), blob_len(b.head));
+	blobmsg_parse(lease_attrs, LEASE_ATTR_MAX, tb, blob_data(ba), blob_len(ba));
 
 	if ((c = tb[LEASE_ATTR_DUID]))
 		duidlen = (blobmsg_data_len(c) - 1) / 2;
@@ -458,6 +447,13 @@ err:
 		free_lease(l);
 
 	return -1;
+}
+
+static int set_lease_from_uci(struct uci_section *s)
+{
+	blob_buf_init(&b, 0);
+	uci_to_blob(&b, s, &lease_attr_list);
+	return set_lease_from_blobmsg(b.head);
 }
 
 int config_parse_interface(void *data, size_t len, const char *name, bool overwrite)
@@ -1072,7 +1068,7 @@ void odhcpd_reload(void)
 		uci_foreach_element(&dhcp->sections, e) {
 			struct uci_section* s = uci_to_section(e);
 			if (!strcmp(s->type, "host"))
-				set_lease(s);
+				set_lease_from_uci(s);
 		}
 	}
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -159,6 +159,15 @@ struct lease {
 	char *hostname;
 };
 
+enum {
+	LEASE_ATTR_IP,
+	LEASE_ATTR_MAC,
+	LEASE_ATTR_DUID,
+	LEASE_ATTR_HOSTID,
+	LEASE_ATTR_LEASETIME,
+	LEASE_ATTR_NAME,
+	LEASE_ATTR_MAX
+};
 
 struct odhcpd_ref_ip;
 
@@ -375,6 +384,7 @@ struct lease *config_find_lease_by_duid(const uint8_t *duid, const uint16_t len)
 struct lease *config_find_lease_by_mac(const uint8_t *mac);
 struct lease *config_find_lease_by_hostid(const uint32_t hostid);
 struct lease *config_find_lease_by_ipaddr(const uint32_t ipaddr);
+int set_lease_from_blobmsg(struct blob_attr *ba);
 
 #ifdef WITH_UBUS
 int ubus_init(void);

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -174,10 +174,22 @@ static int handle_dhcpv6_leases(_unused struct ubus_context *ctx, _unused struct
 	return 0;
 }
 
+static int handle_add_lease(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
+		_unused struct ubus_request_data *req, _unused const char *method,
+		struct blob_attr *msg)
+{
+	if(!set_lease_from_blobmsg(msg))
+		return UBUS_STATUS_OK;
+
+	return UBUS_STATUS_INVALID_ARGUMENT;
+}
+
+extern struct blobmsg_policy lease_attrs[LEASE_ATTR_MAX];
 
 static struct ubus_method main_object_methods[] = {
 	{.name = "ipv4leases", .handler = handle_dhcpv4_leases},
 	{.name = "ipv6leases", .handler = handle_dhcpv6_leases},
+	UBUS_METHOD("add_lease", handle_add_lease, lease_attrs),
 };
 
 static struct ubus_object_type main_object_type =


### PR DESCRIPTION
Allows sharing leases between odhcpd instances running in multiple hosts.
This is my first contribution to odhcpd and my first time using libubox, libuci, libubus so this may be subtly (and not so subtly) wrong. 

Fixes #113 

@altergui can you test it?