### PR TITLE
odhcpd: add support for dhcpv6_pd_min parameter

### DIFF
--- a/README
+++ b/README
@@ -101,6 +101,9 @@ dhcpv6_na		bool	1			DHCPv6 stateful addressing hands out IA_NA -
 								Internet Address - Network Address
 dhcpv6_pd		bool	1			DHCPv6 stateful addressing hands out IA_PD -
 								Internet Address - Prefix Delegation
+dhcpv6_pd_min_len	integer	-			Minimum prefix length to delegate with IA_PD
+							(value is adjusted if needed to be greater
+							than the interface prefix length).  Range [1,62]
 router			list    <local address>		Routers to announce
 							accepts IPv4 only
 dns			list	<local address>		DNS servers to announce

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -350,6 +350,7 @@ struct interface {
 	bool dhcpv6_pd;
 	bool dhcpv6_na;
 	uint32_t dhcpv6_hostid_len;
+	uint32_t dhcpv6_pd_min_len; // minimum delegated prefix length
 
 	char *upstream;
 	size_t upstream_len;


### PR DESCRIPTION
the dhcpv6_pd_min option clamps the requested prefix delegation to be at
least as big as the option.  This allows a router to manage the size of
each downstream router's prefix delegation length independently from the
delegating interface's prefix length.

Signed-off-by: John Kohl <jtk.git@bostonpog.org>