### PR TITLE
fix null pointer dereference for INFORM messages

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -849,7 +849,7 @@ void dhcpv4_handle_msg(void *addr, void *data, size_t len,
 		dhcpv4_put(&reply, &cookie, DHCPV4_OPT_DNSSERVER,
 				4 * iface->dhcpv4_dns_cnt, iface->dhcpv4_dns);
 
-	if (a->reqopts && iface->dhcpv4_ntp_cnt != 0) {
+	if (a && a->reqopts && iface->dhcpv4_ntp_cnt != 0) {
 		for(size_t opts = 0; a->reqopts[opts]; opts++) {
 			if (a->reqopts[opts] == DHCPV4_OPT_NTPSERVER) {
 				dhcpv4_put(&reply, &cookie, DHCPV4_OPT_NTPSERVER,


### PR DESCRIPTION
The variable `a` was unset when an INFORM message was received, causing a segfault. This checks `a` before dereferencing.

Checked by running locally and sending a DHCP INFORM message and verifying that the process does not segfault.