### PR TITLE
config: make sure timer is not on the timeouts list before freeing

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -257,6 +257,9 @@ static void close_interface(struct interface *iface)
 	dhcpv4_setup_interface(iface, false);
 #endif
 
+	/* make sure timer is not on the timeouts list before freeing */
+	uloop_timeout_cancel(&iface->timer_rs);
+
 	clean_interface(iface);
 	free(iface->addr4);
 	free(iface->addr6);


### PR DESCRIPTION
There is a race condition where odhcpd could either hang indefinitely (consuming 100% CPU on 1 core) or crash; usually triggered by network restart. We tracked it back to the uloop timeouts linked list becoming corrupt.. it seems the ra timer is added to the uloop timer list via netlink callback without checking if the timer is already active for the interface. If this happens the interface can get free'd even though the timer is still in the timer list.

Relevant gdb backtrace from one of the failure conditions:
`Program terminated with signal SIGABRT, Aborted.
#0  0x0000007f9aa27220 in tv_diff (t1=t1@entry=0x7f9aae1508, t2=t2@entry=0x7ffb63faf8) at /home/mclark/sandbox/master_4_27/polecat/openwrt/build_dir/target-aarch64_cortex-a53_musl/libubox-2022-09-27-ea560134/uloop.c:256
256			(t1->tv_sec - t2->tv_sec) * 1000 +
#0  0x0000007f9aa27220 in tv_diff (t1=t1@entry=0x7f9aae1508, t2=t2@entry=0x7ffb63faf8) at /home/mclark/sandbox/master_4_27/polecat/openwrt/build_dir/target-aarch64_cortex-a53_musl/libubox-2022-09-27-ea560134/uloop.c:256
#1  0x0000007f9aa27a90 in uloop_process_timeouts (tv=0x7ffb63faf8) at /home/mclark/sandbox/master_4_27/polecat/openwrt/build_dir/target-aarch64_cortex-a53_musl/libubox-2022-09-27-ea560134/uloop.c:521
#2  uloop_run_timeout (timeout=timeout@entry=-1) at /home/mclark/sandbox/master_4_27/polecat/openwrt/build_dir/target-aarch64_cortex-a53_musl/libubox-2022-09-27-ea560134/uloop.c:563
#3  0x0000005593e577f8 in uloop_run () at /home/mclark/sandbox/master_4_27/polecat/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/libubox/uloop.h:112
#4  0x0000005593e54088 in main (argc=<optimized out>, argv=<optimized out>) at /home/mclark/sandbox/master_4_27/polecat/openwrt/build_dir/target-aarch64_cortex-a53_musl/odhcpd-ipv6only/odhcpd-2023-04-05-40ab806b/src/odhcpd.c:133 `