### PR TITLE
dhcpv6: RA - Fix preferred lifetime

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -356,18 +356,14 @@ static double parse_leasetime(struct blob_attr *c) {
 	double time = strcmp(val, "infinite") ? strtod(val, &endptr) : UINT32_MAX;
 
 	if (time && endptr && endptr[0]) {
-		if (endptr[0] == 's')
-			time *= 1;
-		else if (endptr[0] == 'm')
-			time *= 60;
-		else if (endptr[0] == 'h')
-			time *= 3600;
-		else if (endptr[0] == 'd')
-			time *= 24 * 3600;
-		else if (endptr[0] == 'w')
-			time *= 7 * 24 * 3600;
-		else
-			goto err;
+		switch(endptr[0]) {
+			case 's': break;
+			case 'm': time *= 60; break;
+			case 'h': time *= 3600; break;
+			case 'd': time *= 24 * 3600; break;
+			case 'w': time *= 7 * 24 * 3600; break;
+			default: goto err;
+		}
 	}
 
 	if (time < 60)

--- a/src/config.c
+++ b/src/config.c
@@ -892,6 +892,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	if ((c = tb[IFACE_ATTR_RA_DEFAULT]))
 		iface->default_router = blobmsg_get_u32(c);
 
+	/* IFACE_ATTR_RA_MANAGEMENT aka ra_management is deprecated since 2019 */
 	if (!tb[IFACE_ATTR_RA_FLAGS] && !tb[IFACE_ATTR_RA_SLAAC] &&
 	    (c = tb[IFACE_ATTR_RA_MANAGEMENT])) {
 		switch (blobmsg_get_u32(c)) {

--- a/src/config.c
+++ b/src/config.c
@@ -295,8 +295,8 @@ static int parse_ra_flags(uint8_t *flags, struct blob_attr *attr)
 		if (blobmsg_type(cur) != BLOBMSG_TYPE_STRING)
 			continue;
 
-                if (!blobmsg_check_attr(cur, false))
-                        continue;
+				if (!blobmsg_check_attr(cur, false))
+						continue;
 
 		for (i = 0; ra_flags[i].name; i++) {
 			if (!strcmp(ra_flags[i].name, blobmsg_get_string(cur))) {
@@ -599,7 +599,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			goto err;
 
 		if (!iface->ifindex &&
-		    (iface->ifindex = if_nametoindex(iface->ifname)) <= 0)
+			(iface->ifindex = if_nametoindex(iface->ifname)) <= 0)
 			goto err;
 
 		if ((iface->ifflags = odhcpd_get_flags(iface)) < 0)
@@ -643,7 +643,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			iface->dhcp_leasetime = time;
 		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_LEASETIME].name, iface->name);
+					iface_attrs[IFACE_ATTR_LEASETIME].name, iface->name);
 
 	}
 
@@ -654,7 +654,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			iface->preferred_lifetime = time;
 		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_PREFERRED_LIFETIME].name, iface->name);
+					iface_attrs[IFACE_ATTR_PREFERRED_LIFETIME].name, iface->name);
 
 	}
 
@@ -700,7 +700,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 				iface->ignore = false;
 		} else
 			syslog(LOG_ERR, "Invalid %s mode configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_RA].name, iface->name);
+					iface_attrs[IFACE_ATTR_RA].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_DHCPV4])) {
@@ -713,7 +713,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			}
 		} else
 			syslog(LOG_ERR, "Invalid %s mode configured for interface %s",
-			       iface_attrs[IFACE_ATTR_DHCPV4].name, iface->name);
+					iface_attrs[IFACE_ATTR_DHCPV4].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_DHCPV6])) {
@@ -724,7 +724,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 				iface->ignore = false;
 		} else
 			syslog(LOG_ERR, "Invalid %s mode configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_DHCPV6].name, iface->name);
+					iface_attrs[IFACE_ATTR_DHCPV6].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_NDP])) {
@@ -735,7 +735,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 				iface->ignore = false;
 		} else
 			syslog(LOG_ERR, "Invalid %s mode configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_NDP].name, iface->name);
+					iface_attrs[IFACE_ATTR_NDP].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_ROUTER])) {
@@ -757,7 +757,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 				iface->dhcpv4_router[iface->dhcpv4_router_cnt - 1] = addr4;
 			} else
 				syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-				       iface_attrs[IFACE_ATTR_ROUTER].name, iface->name);
+						iface_attrs[IFACE_ATTR_ROUTER].name, iface->name);
 		}
 	}
 
@@ -776,7 +776,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			if (inet_pton(AF_INET, blobmsg_get_string(cur), &addr4) == 1) {
 				if (addr4.s_addr == INADDR_ANY) {
 					syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-					       iface_attrs[IFACE_ATTR_DNS].name, iface->name);
+							iface_attrs[IFACE_ATTR_DNS].name, iface->name);
 
 					continue;
 				}
@@ -790,7 +790,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			} else if (inet_pton(AF_INET6, blobmsg_get_string(cur), &addr6) == 1) {
 				if (IN6_IS_ADDR_UNSPECIFIED(&addr6)) {
 					syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-					       iface_attrs[IFACE_ATTR_DNS].name, iface->name);
+							iface_attrs[IFACE_ATTR_DNS].name, iface->name);
 
 					continue;
 				}
@@ -803,7 +803,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 				iface->dns[iface->dns_cnt - 1] = addr6;
 			} else
 				syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-				       iface_attrs[IFACE_ATTR_DNS].name, iface->name);
+						iface_attrs[IFACE_ATTR_DNS].name, iface->name);
 		}
 	}
 
@@ -832,7 +832,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			len = dn_comp(domain, buf, sizeof(buf), NULL, NULL);
 			if (len <= 0) {
 				syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-				       iface_attrs[IFACE_ATTR_DOMAIN].name, iface->name);
+						iface_attrs[IFACE_ATTR_DOMAIN].name, iface->name);
 
 				continue;
 			}
@@ -872,7 +872,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			iface->dhcpv6_pd_min_len = pd_min_len;
 		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_DHCPV6_PD_MIN_LEN].name, iface->name);
+					iface_attrs[IFACE_ATTR_DHCPV6_PD_MIN_LEN].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_DHCPV6_NA]))
@@ -894,7 +894,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	/* IFACE_ATTR_RA_MANAGEMENT aka ra_management is deprecated since 2019 */
 	if (!tb[IFACE_ATTR_RA_FLAGS] && !tb[IFACE_ATTR_RA_SLAAC] &&
-	    (c = tb[IFACE_ATTR_RA_MANAGEMENT])) {
+		(c = tb[IFACE_ATTR_RA_MANAGEMENT])) {
 		switch (blobmsg_get_u32(c)) {
 		case 0:
 			iface->ra_flags = ND_RA_FLAG_OTHER;
@@ -918,7 +918,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 		if (parse_ra_flags(&iface->ra_flags, c) < 0)
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_RA_FLAGS].name, iface->name);
+					iface_attrs[IFACE_ATTR_RA_FLAGS].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_REACHABLETIME])) {
@@ -928,7 +928,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			iface->ra_reachabletime = ra_reachabletime;
 		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_RA_REACHABLETIME].name, iface->name);
+					iface_attrs[IFACE_ATTR_RA_REACHABLETIME].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_RETRANSTIME])) {
@@ -938,7 +938,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			iface->ra_retranstime = ra_retranstime;
 		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_RA_RETRANSTIME].name, iface->name);
+					iface_attrs[IFACE_ATTR_RA_RETRANSTIME].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_HOPLIMIT])) {
@@ -948,7 +948,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			iface->ra_hoplimit = ra_hoplimit;
 		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_RA_HOPLIMIT].name, iface->name);
+					iface_attrs[IFACE_ATTR_RA_HOPLIMIT].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_MTU])) {
@@ -958,7 +958,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			iface->ra_mtu = ra_mtu;
 		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_RA_MTU].name, iface->name);
+					iface_attrs[IFACE_ATTR_RA_MTU].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_SLAAC]))
@@ -1014,7 +1014,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			iface->route_preference = 0;
 		else
 			syslog(LOG_ERR, "Invalid %s mode configured for interface '%s'",
-			       iface_attrs[IFACE_ATTR_RA_PREFERENCE].name, iface->name);
+					iface_attrs[IFACE_ATTR_RA_PREFERENCE].name, iface->name);
 	}
 
 	if ((c = tb[IFACE_ATTR_PD_MANAGER]))
@@ -1024,7 +1024,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	if ((c = tb[IFACE_ATTR_PD_CER]) &&
 			inet_pton(AF_INET6, blobmsg_get_string(c), &iface->dhcpv6_pd_cer) < 1)
 		syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-		       iface_attrs[IFACE_ATTR_PD_CER].name, iface->name);
+				iface_attrs[IFACE_ATTR_PD_CER].name, iface->name);
 
 	if ((c = tb[IFACE_ATTR_NDPROXY_ROUTING]))
 		iface->learn_routes = blobmsg_get_bool(c);
@@ -1149,7 +1149,7 @@ static int lease_cmp(const void *k1, const void *k2, _unused void *ptr)
 		return cmp;
 
 	return memcmp(l1->mac.ether_addr_octet, l2->mac.ether_addr_octet,
-		      sizeof(l1->mac.ether_addr_octet));
+				sizeof(l1->mac.ether_addr_octet));
 }
 
 static void lease_change_config(struct lease *l_old, struct lease *l_new)
@@ -1157,7 +1157,7 @@ static void lease_change_config(struct lease *l_old, struct lease *l_new)
 	bool update = false;
 
 	if ((!!l_new->hostname != !!l_old->hostname) ||
-	    (l_new->hostname && strcmp(l_new->hostname, l_old->hostname))) {
+		(l_new->hostname && strcmp(l_new->hostname, l_old->hostname))) {
 		free(l_old->hostname);
 		l_old->hostname = NULL;
 
@@ -1228,7 +1228,7 @@ struct lease *config_find_lease_by_mac(const uint8_t *mac)
 
 	vlist_for_each_element(&leases, l, node) {
 		if (!memcmp(l->mac.ether_addr_octet, mac,
-			    sizeof(l->mac.ether_addr_octet)))
+				sizeof(l->mac.ether_addr_octet)))
 			return l;
 	}
 

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -893,7 +893,7 @@ void dhcpv4_handle_msg(void *addr, void *data, size_t len,
 		struct arpreq arp = {.arp_flags = ATF_COM};
 
 		/*
-		 * send reply to the newly (in this proccess) allocated IP
+		 * send reply to the newly (in this process) allocated IP
 		 */
 		dest.sin_addr = reply.yiaddr;
 		dest.sin_port = htons(DHCPV4_CLIENT_PORT);

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1142,11 +1142,11 @@ static size_t build_ia(uint8_t *buf, size_t buflen, uint16_t status,
 		}
 
 		if (!INFINITE_VALID(a->valid_until))
-			/* UINT32_MAX is considered as infinite leasetime */
+			/* UINT32_MAX is RFC defined as infinite lease-time */
 			a->valid_until = (valid_lt == UINT32_MAX) ? 0 : valid_lt + now;
 
 		if (!INFINITE_VALID(a->preferred_until))
-			/* UINT32_MAX is considered as infinite leasetime */
+			/* UINT32_MAX is RFC defined as infinite lease-time */
 			a->preferred_until = (preferred_lt == UINT32_MAX) ? 0 : preferred_lt + now;
 
 		o_ia.t1 = htonl((preferred_lt == UINT32_MAX) ? preferred_lt : preferred_lt * 5 / 10);
@@ -1570,7 +1570,7 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 				/* Set error status */
 				status = (is_pd) ? DHCPV6_STATUS_NOPREFIXAVAIL : DHCPV6_STATUS_NOADDRSAVAIL;
 			else if (hdr->msg_type == DHCPV6_MSG_REQUEST && !dhcpv6_ia_on_link(ia, a, iface)) {
-				/* Send NOTONLINK staus for the IA */
+				/* Send NOTONLINK status for the IA */
 				status = DHCPV6_STATUS_NOTONLINK;
 				assigned = false;
 			} else if (accept_reconf && assigned && !first &&

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -773,7 +773,7 @@ static struct odhcpd_ipaddr *relay_link_address(struct interface *iface)
 		if (iface->addr6[i].valid <= (uint32_t)now)
 			continue;
 
-		if (iface->addr6[i].preferred > (uint32_t)now) {
+		if (iface->addr6[i].preferred_lt > (uint32_t)now) {
 			addr = &iface->addr6[i];
 			break;
 		}

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -770,7 +770,7 @@ static struct odhcpd_ipaddr *relay_link_address(struct interface *iface)
 	time_t now = odhcpd_time();
 
 	for (size_t i = 0; i < iface->addr6_len; i++) {
-		if (iface->addr6[i].valid <= (uint32_t)now)
+		if (iface->addr6[i].valid_lt <= (uint32_t)now)
 			continue;
 
 		if (iface->addr6[i].preferred_lt > (uint32_t)now) {
@@ -778,7 +778,7 @@ static struct odhcpd_ipaddr *relay_link_address(struct interface *iface)
 			break;
 		}
 
-		if (!addr || (iface->addr6[i].valid > addr->valid))
+		if (!addr || (iface->addr6[i].valid_lt > addr->valid_lt))
 			addr = &iface->addr6[i];
 	}
 

--- a/src/dhcpv6.h
+++ b/src/dhcpv6.h
@@ -130,7 +130,7 @@ struct dhcpv6_ia_hdr {
 struct dhcpv6_ia_prefix {
 	uint16_t type;
 	uint16_t len;
-	uint32_t preferred;
+	uint32_t preferred_lt;
 	uint32_t valid;
 	uint8_t prefix;
 	struct in6_addr addr;
@@ -140,7 +140,7 @@ struct dhcpv6_ia_addr {
 	uint16_t type;
 	uint16_t len;
 	struct in6_addr addr;
-	uint32_t preferred;
+	uint32_t preferred_lt;
 	uint32_t valid;
 } _packed;
 

--- a/src/dhcpv6.h
+++ b/src/dhcpv6.h
@@ -131,7 +131,7 @@ struct dhcpv6_ia_prefix {
 	uint16_t type;
 	uint16_t len;
 	uint32_t preferred_lt;
-	uint32_t valid;
+	uint32_t valid_lt;
 	uint8_t prefix;
 	struct in6_addr addr;
 } _packed;
@@ -141,7 +141,7 @@ struct dhcpv6_ia_addr {
 	uint16_t len;
 	struct in6_addr addr;
 	uint32_t preferred_lt;
-	uint32_t valid;
+	uint32_t valid_lt;
 } _packed;
 
 struct dhcpv6_cer_id {

--- a/src/ndp.c
+++ b/src/ndp.c
@@ -39,7 +39,7 @@ static void setup_addr_for_relaying(struct in6_addr *addr, struct interface *ifa
 static void handle_solicit(void *addr, void *data, size_t len,
 		struct interface *iface, void *dest);
 
-/* Filter ICMPv6 messages of type neighbor soliciation */
+/* Filter ICMPv6 messages of type neighbor solicitation */
 static struct sock_filter bpf[] = {
 	BPF_STMT(BPF_LD | BPF_B | BPF_ABS, offsetof(struct ip6_hdr, ip6_nxt)),
 	BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_ICMPV6, 0, 3),
@@ -343,7 +343,7 @@ static void handle_solicit(void *addr, void *data, size_t len,
 		return;
 
 	if (len < sizeof(*ip6) + sizeof(*req))
-		return; // Invalid reqicitation
+		return; // Invalid total length
 
 	if (IN6_IS_ADDR_LINKLOCAL(&req->nd_ns_target) ||
 			IN6_IS_ADDR_LOOPBACK(&req->nd_ns_target) ||

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -213,7 +213,7 @@ static void refresh_iface_addr6(int ifindex)
 
 			if (change) {
 				/*
-				 * Keep track on removed prefixes, so we could advertise them as invalid
+				 * Keep track of removed prefixes, so we could advertise them as invalid
 				 * for at least a couple of times.
 				 *
 				 * RFC7084 § 4.3 :

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -277,8 +277,8 @@ int odhcpd_get_interface_dns_addr(const struct interface *iface, struct in6_addr
 			continue;
 		}
 
-		if (iface->addr6[m].preferred >= (uint32_t)now &&
-				iface->addr6[i].preferred < (uint32_t)now)
+		if (iface->addr6[m].preferred_lt >= (uint32_t)now &&
+				iface->addr6[i].preferred_lt < (uint32_t)now)
 			continue;
 
 		if (IN6_IS_ADDR_ULA(&iface->addr6[i].addr.in6)) {
@@ -289,7 +289,7 @@ int odhcpd_get_interface_dns_addr(const struct interface *iface, struct in6_addr
 		} else if (IN6_IS_ADDR_ULA(&iface->addr6[m].addr.in6))
 			continue;
 
-		if (iface->addr6[i].preferred > iface->addr6[m].preferred)
+		if (iface->addr6[i].preferred_lt > iface->addr6[m].preferred_lt)
 			m = i;
 	}
 

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -269,7 +269,7 @@ int odhcpd_get_interface_dns_addr(const struct interface *iface, struct in6_addr
 		return -1;
 
 	for (size_t i = 0; i < iface->addr6_len; ++i) {
-		if (iface->addr6[i].valid <= (uint32_t)now)
+		if (iface->addr6[i].valid_lt <= (uint32_t)now)
 			continue;
 
 		if (m < 0) {

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -126,7 +126,7 @@ struct netevent_handler {
 struct odhcpd_ipaddr {
 	union if_addr addr;
 	uint8_t prefix;
-	uint32_t preferred;
+	uint32_t preferred_lt;
 	uint32_t valid;
 
 	union {

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -127,7 +127,7 @@ struct odhcpd_ipaddr {
 	union if_addr addr;
 	uint8_t prefix;
 	uint32_t preferred_lt;
-	uint32_t valid;
+	uint32_t valid_lt;
 
 	union {
 		/* ipv6 only */

--- a/src/router.c
+++ b/src/router.c
@@ -709,7 +709,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	iov[IOV_RA_SEARCH].iov_len = search_sz;
 
 	if (iface->pref64_length) {
-		/* RFC 8781 § 4.1 rounding up lifetime to multiply of 8 */
+		/* RFC 8781 § 4.1 rounding up lifetime to multiple of 8 */
 		uint16_t pref64_lifetime = lifetime < (UINT16_MAX - 7) ? lifetime + 7 : UINT16_MAX;
 		uint8_t prefix_length_code;
 		uint32_t mask_a1, mask_a2;

--- a/src/router.c
+++ b/src/router.c
@@ -590,9 +590,10 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 		if (addr->preferred_lt > (uint32_t)now) {
 			preferred_lt = TIME_LEFT(addr->preferred_lt, now);
 
-			if (iface->ra_useleasetime &&
-			    preferred_lt > iface->preferred_lifetime)
+			if (preferred_lt > iface->preferred_lifetime) {
+				// set to possibly user mandated preferred_lt
 				preferred_lt = iface->preferred_lifetime;
+			}
 		}
 
 		if (addr->valid_lt > (uint32_t)now) {

--- a/src/router.c
+++ b/src/router.c
@@ -603,6 +603,13 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 				valid_lt = iface->dhcp_leasetime;
 		}
 
+		if (preferred_lt > valid_lt) {
+			/* RFC4861 § 6.2.1
+			This value [AdvPreferredLifetime] MUST NOT be larger than AdvValidLifetime.
+			*/
+			preferred_lt = valid_lt;
+		}
+
 		if (minvalid > valid_lt)
 			minvalid = valid_lt;
 

--- a/src/router.c
+++ b/src/router.c
@@ -666,7 +666,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 		uint8_t *search_domain = iface->search;
 		uint8_t search_buf[256];
 
-		/* DNS Recursive DNS */
+		/* DNS Recursive DNS aka RDNSS Type 25; RFC8106 */
 		if (iface->dns_cnt > 0) {
 			dns_addr = iface->dns;
 			dns_cnt = iface->dns_cnt;
@@ -686,7 +686,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 			memcpy(dns->addr, dns_addr, sizeof(struct in6_addr)*dns_cnt);
 		}
 
-		/* DNS Search options */
+		/* DNS Search options aka DNSSL Type 31; RFC8106 */
 		if (!search_domain && !res_init() && _res.dnsrch[0] && _res.dnsrch[0][0]) {
 			int len = dn_comp(_res.dnsrch[0], search_buf,
 					sizeof(search_buf), NULL, NULL);

--- a/src/router.c
+++ b/src/router.c
@@ -656,9 +656,9 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 
 		if (default_route) {
 			syslog(LOG_WARNING, "A default route is present but there is no public prefix "
-					    "on %s thus we don't announce a default route by overriding ra_lifetime!", iface->name);
+					    "on %s thus we announce no default route by overriding ra_lifetime to 0!", iface->name);
 		} else {
-			syslog(LOG_WARNING, "No default route present, overriding ra_lifetime!");
+			syslog(LOG_WARNING, "No default route present, overriding ra_lifetime to 0!");
 		}
 	}
 


### PR DESCRIPTION
Comments welcome. 

Would appreciate input from @dedeckeh and @PolynomialDivision who seem most familiar with the RA bits.

Tested on 23.05.0

## Example Data

Set `preferred_lifetime` to `7m` in GUI (without setting `ra_useleasetime`)

The following are ICMP Options from ICMPv6 RA packets.

Before patch:

```
ICMPv6 Option (Prefix information : fd51:1c2a:8909::/64)
    Type: Prefix information (3)
    Length: 4 (32 bytes)
    Prefix Length: 64
    Flag: 0xc0, On-link flag(L), Autonomous address-configuration flag(A)
    Valid Lifetime: Infinity (4294967295)
    Preferred Lifetime: Infinity (4294967295)
    Reserved
    Prefix: fd51:1c2a:8909::
```

After patch:
```
ICMPv6 Option (Prefix information : fd51:1c2a:8909::/64)
    Type: Prefix information (3)
    Length: 4 (32 bytes)
    Prefix Length: 64
    Flag: 0xc0, On-link flag(L), Autonomous address-configuration flag(A)
    Valid Lifetime: Infinity (4294967295)
    Preferred Lifetime: 420
    Reserved
    Prefix: fd51:1c2a:8909::
```