### PR TITLE
router: skip warning when configured lifetime is 0

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -638,7 +638,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 
 	if (default_route && valid_prefix) {
 		adv.h.nd_ra_router_lifetime = htons(lifetime < UINT16_MAX ? lifetime : UINT16_MAX);
-	} else {
+	} else if (lifetime) {
 		adv.h.nd_ra_router_lifetime = 0;
 
 		if (default_route) {


### PR DESCRIPTION
The configured lifetime is overridden to be 0 in certain cases where advertising a positive lifetime is not sensible. A log warning is only warranted if the user was not already aware of this condition and erroneously set the lifetime to a positive value.

If the user acknowledges these conditions by manually configuring a 0 lifetime, we should not warn them of the override.