### PR TITLE
router: implement RFC 7084 errata 7699

### DIFF
--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -78,6 +78,7 @@ int main(int argc, char **argv)
 {
 	openlog("odhcpd", LOG_PERROR | LOG_PID, LOG_DAEMON);
 	int opt;
+	bool ipv6 = ipv6_enabled();
 
 	while ((opt = getopt(argc, argv, "hl:")) != -1) {
 		switch (opt) {
@@ -110,10 +111,10 @@ int main(int argc, char **argv)
 	signal(SIGINT, sighandler);
 	signal(SIGTERM, sighandler);
 
-	if (netlink_init())
+	if (netlink_init(ipv6))
 		return 4;
 
-	if (ipv6_enabled()) {
+	if (ipv6) {
 		if (router_init())
 			return 4;
 


### PR DESCRIPTION
RFC 7084 L-3 requires router advertisement daemon to send RIO for every prefix delegation that allocates a prefix on the interface. There is one special case though where PIO advertise the on-link prefix route that conflicts with the RIO prefix.

Example:
 - CE-Router receives IA-PD 2001:db8:1234::/64
 - this prefix delegation gets assigned to the lan interface
 - odhcpd advertise on-link PIO with prefix 2001:db8:1234::/64

If original RFC 7084 L-3 would be followed, RA will also contain a RIO with prefix 2001:db8:1234::/64 which will require lan hosts to add the routes
   2001:db8:1234::/64 dev br-lan # the on-link prefix route
   2001:db8:1234::/64 dev br-lan nexthop fe80::1 # RIO route