### PR TITLE
router: add option to include custom routes in RA

### DIFF
--- a/README
+++ b/README
@@ -67,6 +67,8 @@ leasefile	string				DHCP/v6 lease/hostfile
 leasetrigger	string				Lease trigger script
 hostsfile	string				DHCP/v6 hostfile
 loglevel	integer 6			Syslog level priority (0-7)
+ra_staticroute	list	string			Announced static routes for all interfaces
+		[IPv6 prefix]			(used if RA doesn't include default router info already)
 
 
 Sections of type dhcp (configure DHCP / DHCPv6 / RA / NDP service)
@@ -149,6 +151,8 @@ ra_mtu			integer -			MTU to be advertised in
 							RA messages
 ra_dns			bool	1			Announce DNS configuration in
 							RA messages (RFC8106)
+ra_staticroute		list	string			Announced static routes
+			[IPv6 prefix]			(used if RA doesn't include default router info already)
 ra_pref64		string				Announce PREF64 option
 			[IPv6 prefix]			for NAT64 prefix (RFC8781)
 ndproxy_routing		bool	1			Learn routes from NDP

--- a/src/config.c
+++ b/src/config.c
@@ -1853,6 +1853,8 @@ void odhcpd_reload(void)
 	if (!uci)
 		return;
 
+	syslog(LOG_NOTICE, "Reloading...");
+
 	vlist_update(&leases);
 	avl_for_each_element(&interfaces, i, avl)
 		clean_interface(i);

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -623,6 +623,28 @@ bool odhcpd_bitlen2netmask(bool inet6, unsigned int bits, void *mask)
 	return true;
 }
 
+/* `addr` and `network` can be the same memory location */
+bool odhcpd_addr6_to_network(const struct in6_addr *addr, uint8_t prefix,
+			     struct in6_addr *network)
+{
+	if (prefix > 128) {
+		return false;
+	}
+
+	/* Calculate mask */
+	struct in6_addr mask;
+	if (!odhcpd_bitlen2netmask(true, prefix, &mask)) {
+		return false;
+	}
+
+	/* Apply the mask */
+	for (unsigned int i = 0; i < sizeof(mask.s6_addr); i++) {
+		network->s6_addr[i] = addr->s6_addr[i] & mask.s6_addr[i];
+	}
+
+	return true;
+}
+
 bool odhcpd_valid_hostname(const char *name)
 {
 #define MAX_LABEL	63

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -145,6 +145,11 @@ struct odhcpd_ipaddr {
 	};
 };
 
+struct odhcpd_ip6prefix {
+	struct in6_addr addr;
+	uint8_t len;
+};
+
 enum odhcpd_mode {
 	MODE_DISABLED,
 	MODE_SERVER,
@@ -170,6 +175,10 @@ struct config {
 	char *dhcp_statefile;
 	char *dhcp_hostsfile;
 	int log_level;
+
+	// Global RA settings
+	struct odhcpd_ip6prefix *ra_static_routes;
+	size_t ra_static_routes_cnt;
 };
 
 
@@ -332,6 +341,8 @@ struct interface {
 	uint8_t pref64_length;
 	uint8_t pref64_plc;
 	uint32_t pref64_prefix[3];
+	struct odhcpd_ip6prefix *ra_static_routes;
+	size_t ra_static_routes_cnt;
 	bool no_dynamic_dhcp;
 	bool have_link_local;
 	uint8_t pio_filter_length;
@@ -457,6 +468,8 @@ void odhcpd_bmemcpy(void *av, const void *bv, size_t bits);
 int odhcpd_parse_addr6_prefix(const char *str, struct in6_addr *addr, uint8_t *prefix);
 int odhcpd_netmask2bitlen(bool v6, void *mask);
 bool odhcpd_bitlen2netmask(bool v6, unsigned int bits, void *mask);
+bool odhcpd_addr6_to_network(const struct in6_addr *addr, uint8_t prefix,
+			     struct in6_addr *network);
 bool odhcpd_valid_hostname(const char *name);
 
 int config_parse_interface(void *data, size_t len, const char *iname, bool overwrite);


### PR DESCRIPTION
Introduces new configuration option `ra_staticroute` for adding custom route(s) in route advertisement (RA) messages when no default route is advertised.

This is useful when, for example, end devices are given only ULA IPv6 addresses (e.g. from `fc00:0:100::/48`), but one still needs inter subnet communication to e.g. `fc00:0:200::/48`. Currently, this wouldn't be possible without static route on each end device as the odhcpd server doesn't present itself as default router and no route information is given except for local ULA subnet (`fc00:0:100::/48`).

New configuration option `ra_staticroute` makes it possible to advertise arbitrary routes to the end devices and thus making correct routing possible even when no default route (or public IPv6 prefix) is available.

Option `ra_staticroute` exists under both `odhcpd` section and interfaces' sections. Latter sets up interface-specific routes. Routes configured under `odhcpd` are global and advertised for all interfaces (including those with interface-specific static routes).

Config example:

```
config odhcpd 'odhcpd'
	...
	list ra_staticroute 'fc00:10::/32'
	list ra_staticroute 'fc00:20::/32'

config dhcp 'lan'
	...
	list ra_staticroute 'fd50:60:70::/48'
```

Fixes: https://github.com/openwrt/odhcpd/issues/74 and possibly helps with https://github.com/openwrt/odhcpd/issues/152