### PR TITLE
config: clamp configurable values to within sensible ranges

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -431,18 +431,14 @@ static double parse_leasetime(struct blob_attr *c) {
 	double time = strcmp(val, "infinite") ? strtod(val, &endptr) : UINT32_MAX;
 
 	if (time && endptr && endptr[0]) {
-		if (endptr[0] == 's')
-			time *= 1;
-		else if (endptr[0] == 'm')
-			time *= 60;
-		else if (endptr[0] == 'h')
-			time *= 3600;
-		else if (endptr[0] == 'd')
-			time *= 24 * 3600;
-		else if (endptr[0] == 'w')
-			time *= 7 * 24 * 3600;
-		else
-			goto err;
+		switch(endptr[0]) {
+			case 's': break; /* seconds */
+			case 'm': time *= 60; break; /* minutes */
+			case 'h': time *= 3600; break; /* hours */
+			case 'd': time *= 24 * 3600; break; /* days */
+			case 'w': time *= 7 * 24 * 3600; break; /* weeks */
+			default: goto err;
+		}
 	}
 
 	if (time < 60)

--- a/src/config.c
+++ b/src/config.c
@@ -1314,14 +1314,20 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 		iface->dhcpv6_na = blobmsg_get_bool(c);
 
 	if ((c = tb[IFACE_ATTR_DHCPV6_HOSTID_LEN])) {
-		uint32_t hostid_len = blobmsg_get_u32(c);
+		uint32_t original_hostid_len, hostid_len;
+		original_hostid_len = hostid_len = blobmsg_get_u32(c);
 
-		if (hostid_len >= HOSTID_LEN_MIN && hostid_len <= HOSTID_LEN_MAX)
-			iface->dhcpv6_hostid_len = hostid_len;
-		else
-			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-				iface_attrs[IFACE_ATTR_DHCPV6_HOSTID_LEN].name, iface->name);
+		if (hostid_len < HOSTID_LEN_MIN)
+			hostid_len = HOSTID_LEN_MIN;
+		else if (hostid_len > HOSTID_LEN_MAX)
+			hostid_len = HOSTID_LEN_MAX;
 
+		iface->dhcpv6_hostid_len = hostid_len;
+
+		if (original_hostid_len != hostid_len) {
+			syslog(LOG_WARNING, "Clamped invalid %s value configured for interface '%s' to %d",
+				   iface_attrs[IFACE_ATTR_DHCPV6_HOSTID_LEN].name, iface->name, iface->dhcpv6_hostid_len);
+		}
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_DEFAULT]))

--- a/src/config.c
+++ b/src/config.c
@@ -1381,11 +1381,12 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	if ((c = tb[IFACE_ATTR_RA_HOPLIMIT])) {
 		uint32_t ra_hoplimit = blobmsg_get_u32(c);
 
-		if (ra_hoplimit <= 255)
-			iface->ra_hoplimit = ra_hoplimit;
-		else
-			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-					iface_attrs[IFACE_ATTR_RA_HOPLIMIT].name, iface->name);
+		/* RFC4861 §6.2.1 : AdvCurHopLimit */
+		iface->ra_hoplimit = ra_hoplimit <= AdvCurHopLimit ? ra_hoplimit : AdvCurHopLimit;
+		if(ra_hoplimit > AdvCurHopLimit)
+			syslog(LOG_WARNING, "Clamped invalid %s value configured for interface '%s' to %d",
+					iface_attrs[IFACE_ATTR_RA_HOPLIMIT].name, iface->name, iface->ra_hoplimit);
+
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_MTU])) {

--- a/src/config.c
+++ b/src/config.c
@@ -431,9 +431,9 @@ static void set_config(struct uci_section *s)
 	}
 }
 
-static double parse_leasetime(struct blob_attr *c) {
+static uint32_t parse_leasetime(struct blob_attr *c) {
 	char *val = blobmsg_get_string(c), *endptr = NULL;
-	double time = strcmp(val, "infinite") ? strtod(val, &endptr) : UINT32_MAX;
+	uint32_t time = strcmp(val, "infinite") ? (uint32_t)strtod(val, &endptr) : UINT32_MAX;
 
 	if (time && endptr && endptr[0]) {
 		switch(endptr[0]) {
@@ -452,7 +452,7 @@ static double parse_leasetime(struct blob_attr *c) {
 	return time;
 
 err:
-	return -1;
+	return 0;
 }
 
 static void free_lease(struct lease *l)
@@ -585,8 +585,8 @@ int set_lease_from_blobmsg(struct blob_attr *ba)
 	}
 
 	if ((c = tb[LEASE_ATTR_LEASETIME])) {
-		double time = parse_leasetime(c);
-		if (time < 0)
+		uint32_t time = parse_leasetime(c);
+		if (time == 0)
 			goto err;
 
 		l->leasetime = time;
@@ -1061,9 +1061,9 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 		iface->no_dynamic_dhcp = !blobmsg_get_bool(c);
 
 	if ((c = tb[IFACE_ATTR_LEASETIME])) {
-		double time = parse_leasetime(c);
+		uint32_t time = parse_leasetime(c);
 
-		if (time >= 0)
+		if (time > 0)
 			iface->dhcp_leasetime = time;
 		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
@@ -1072,25 +1072,25 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	}
 
 	if ((c = tb[IFACE_ATTR_MAX_PREFERRED_LIFETIME])) {
-		double time = parse_leasetime(c);
+		uint32_t time = parse_leasetime(c);
 
-		if (time >= 0) {
+		if (time > 0)
 			iface->max_preferred_lifetime = time;
-		} else {
+		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
 			       iface_attrs[IFACE_ATTR_MAX_PREFERRED_LIFETIME].name, iface->name);
-		}
+
 	}
 
 	if ((c = tb[IFACE_ATTR_MAX_VALID_LIFETIME])) {
-		double time = parse_leasetime(c);
+		uint32_t time = parse_leasetime(c);
 
-		if (time >= 0) {
+		if (time > 0)
 			iface->max_valid_lifetime = time;
-		} else {
+		else
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
 			       iface_attrs[IFACE_ATTR_MAX_VALID_LIFETIME].name, iface->name);
-		}
+
 	}
 
 	if ((c = tb[IFACE_ATTR_START])) {

--- a/src/config.c
+++ b/src/config.c
@@ -1371,11 +1371,10 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	if ((c = tb[IFACE_ATTR_RA_RETRANSTIME])) {
 		uint32_t ra_retranstime = blobmsg_get_u32(c);
 
-		if (ra_retranstime <= 60000)
-			iface->ra_retranstime = ra_retranstime;
-		else
-			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-					iface_attrs[IFACE_ATTR_RA_RETRANSTIME].name, iface->name);
+		iface->ra_retranstime = ra_retranstime <= RETRANS_TIMER_MAX ? ra_retranstime : RETRANS_TIMER_MAX;
+		if (ra_retranstime > RETRANS_TIMER_MAX)
+			syslog(LOG_WARNING, "Clamped invalid %s value configured for interface '%s' to %d",
+					iface_attrs[IFACE_ATTR_RA_RETRANSTIME].name, iface->name, iface->ra_retranstime);
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_HOPLIMIT])) {

--- a/src/config.c
+++ b/src/config.c
@@ -1428,8 +1428,8 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 		uint32_t ra_mininterval = blobmsg_get_u32(c);
 		if (ra_mininterval < MinRtrAdvInterval)
 			ra_mininterval = MinRtrAdvInterval; // clamp min
-		else if (ra_mininterval > (0.75 * (uint32_t)iface->ra_maxinterval)) 
-				ra_mininterval = 0.75 * (uint32_t)iface->ra_maxinterval; // clamp max
+		else if (ra_mininterval > (0.75 * iface->ra_maxinterval)) 
+				ra_mininterval = 0.75 * iface->ra_maxinterval; // clamp max
 		iface->ra_mininterval = ra_mininterval;
 	}
 
@@ -1442,8 +1442,8 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	if ((c = tb[IFACE_ATTR_RA_LIFETIME])){
 		uint32_t ra_lifetime = blobmsg_get_u32(c);
 		if (ra_lifetime != 0){
-			if (ra_lifetime < (uint32_t)iface->ra_maxinterval) 
-				ra_lifetime = (uint32_t)iface->ra_maxinterval; // clamp min
+			if (ra_lifetime < iface->ra_maxinterval) 
+				ra_lifetime = iface->ra_maxinterval; // clamp min
 			else if (ra_lifetime > AdvDefaultLifetime)
 				ra_lifetime = AdvDefaultLifetime; // clamp max
 		}

--- a/src/config.c
+++ b/src/config.c
@@ -1303,11 +1303,12 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_DHCPV6_PD_MIN_LEN])) {
 		uint32_t pd_min_len = blobmsg_get_u32(c);
-		if (pd_min_len != 0 && pd_min_len <= PD_MIN_LEN_MAX)
-			iface->dhcpv6_pd_min_len = pd_min_len;
-		else
-			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-					iface_attrs[IFACE_ATTR_DHCPV6_PD_MIN_LEN].name, iface->name);
+		if (pd_min_len > PD_MIN_LEN_MAX)
+			iface->dhcpv6_pd_min_len = PD_MIN_LEN_MAX;
+		iface->dhcpv6_pd_min_len = pd_min_len;
+		if (pd_min_len >= PD_MIN_LEN_MAX)
+			syslog(LOG_WARNING, "Clamped invalid %s value configured for interface '%s' to %d",
+					iface_attrs[IFACE_ATTR_DHCPV6_PD_MIN_LEN].name, iface->name, iface->dhcpv6_pd_min_len);
 	}
 
 	if ((c = tb[IFACE_ATTR_DHCPV6_NA]))

--- a/src/config.c
+++ b/src/config.c
@@ -20,6 +20,7 @@
 #include <libubox/vlist.h>
 
 #include "odhcpd.h"
+#include "router.h"
 #include "dhcpv6-pxe.h"
 
 static struct blob_buf b;
@@ -289,8 +290,12 @@ static void set_interface_defaults(struct interface *iface)
 	iface->ra_flags = ND_RA_FLAG_OTHER;
 	iface->ra_slaac = true;
 	iface->ra_maxinterval = 600;
+	/*
+	 * RFC4861: MinRtrAdvInterval: Default: 0.33 * MaxRtrAdvInterval If
+	 * MaxRtrAdvInterval >= 9 seconds; otherwise, the Default is MaxRtrAdvInterval.
+	 */
 	iface->ra_mininterval = iface->ra_maxinterval/3;
-	iface->ra_lifetime = -1;
+	iface->ra_lifetime = 3 * iface->ra_maxinterval; /* RFC4861: AdvDefaultLifetime: Default: 3 * MaxRtrAdvInterval */
 	iface->ra_dns = true;
 	iface->pio_update = false;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -1389,13 +1389,18 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_MTU])) {
-		uint32_t ra_mtu = blobmsg_get_u32(c);
+		uint32_t original_ra_mtu, ra_mtu;
+		original_ra_mtu = ra_mtu = blobmsg_get_u32(c);
+		if (ra_mtu < RA_MTU_MIN)
+			ra_mtu = RA_MTU_MIN;
+		else if (ra_mtu > RA_MTU_MAX)
+			ra_mtu = RA_MTU_MAX;
+		iface->ra_mtu = ra_mtu;
 
-		if (ra_mtu >= 1280 || ra_mtu <= 65535)
-			iface->ra_mtu = ra_mtu;
-		else
-			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
-					iface_attrs[IFACE_ATTR_RA_MTU].name, iface->name);
+		if (original_ra_mtu != ra_mtu) {
+			syslog(LOG_WARNING, "Clamped invalid %s value configured for interface '%s' to %d",
+				iface_attrs[IFACE_ATTR_RA_MTU].name, iface->name, iface->ra_mtu);
+		}
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_SLAAC]))

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -364,7 +364,7 @@ struct interface {
 	int route_preference;
 	int ra_maxinterval;
 	int ra_mininterval;
-	int ra_lifetime;
+	uint32_t ra_lifetime;
 	uint32_t ra_reachabletime;
 	uint32_t ra_retranstime;
 	uint32_t ra_hoplimit;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -362,8 +362,8 @@ struct interface {
 	struct in6_addr pio_filter_addr;
 	int default_router;
 	int route_preference;
-	int ra_maxinterval;
-	int ra_mininterval;
+	uint32_t ra_maxinterval;
+	uint32_t ra_mininterval;
 	uint32_t ra_lifetime;
 	uint32_t ra_reachabletime;
 	uint32_t ra_retranstime;

--- a/src/router.c
+++ b/src/router.c
@@ -363,7 +363,7 @@ static uint32_t calc_ra_lifetime(struct interface *iface, uint32_t maxival)
 {
 	uint32_t lifetime = iface->max_preferred_lifetime;
 
-	if (iface->ra_lifetime >= 0) {
+	if (iface->ra_lifetime > 0) {
 		lifetime = iface->ra_lifetime;
 	}
 

--- a/src/router.c
+++ b/src/router.c
@@ -379,8 +379,8 @@ static uint32_t calc_ra_lifetime(struct interface *iface, uint32_t maxival)
 
 	if (lifetime > 0 && lifetime < maxival)
 		lifetime = maxival;
-	else if (lifetime > 9000)
-		lifetime = 9000;
+	else if (lifetime > RouterLifetime)
+		lifetime = RouterLifetime;
 
 	return lifetime;
 }

--- a/src/router.c
+++ b/src/router.c
@@ -345,16 +345,6 @@ static int calc_adv_interval(struct interface *iface, uint32_t lowest_found_life
 	if (*maxival > lowest_found_lifetime)
 		*maxival = lowest_found_lifetime;
 
-	if (*maxival > MaxRtrAdvInterval)
-		*maxival = MaxRtrAdvInterval;
-	else if (*maxival < 4)
-		*maxival = 4;
-
-	if (minival < MinRtrAdvInterval)
-		minival = MinRtrAdvInterval;
-	else if (minival > (*maxival * 3)/4)
-		minival = (*maxival >= 9 ? *maxival/3 : *maxival);
-
 	odhcpd_urandom(&msecs, sizeof(msecs));
 	msecs = (labs(msecs) % ((*maxival != minival) ? (*maxival - minival)*1000 : 500)) +
 			minival*1000;

--- a/src/router.h
+++ b/src/router.h
@@ -66,6 +66,10 @@ struct icmpv6_opt {
 	define is used to cap values to a sane ceiling, i.e. ND_VALID_LIMIT.
 */
 #define RouterLifetime					5400
+/* RFC4861 §6.2.1 : AdvReachableTime : 
+ * MUST be no greater than 3,600,000 msec
+ */
+#define AdvReachableTime				3600000
 
 #define ND_RA_FLAG_PROXY		0x4
 #define ND_RA_PREF_HIGH			(1 << 3)

--- a/src/router.h
+++ b/src/router.h
@@ -70,6 +70,14 @@ struct icmpv6_opt {
  * MUST be no greater than 3,600,000 msec
  */
 #define AdvReachableTime				3600000
+/* RFC4861 §6.2.1 : AdvCurHopLimit 
+	The value should be set to the current
+	diameter of the Internet.  The value zero means
+	unspecified (by this router).
+
+	Note: this value is an 8 bit int, so max 255.
+*/
+#define AdvCurHopLimit					255
 
 #define ND_RA_FLAG_PROXY		0x4
 #define ND_RA_PREF_HIGH			(1 << 3)

--- a/src/router.h
+++ b/src/router.h
@@ -32,8 +32,29 @@ struct icmpv6_opt {
 
 #define MaxInitialRtrAdvInterval	16
 #define MaxInitialRtAdvs		3
-#define MaxRtrAdvInterval		1800
-#define MinRtrAdvInterval		3
+/* RFC8319 §4
+	This document updates §4.2 and 6.2.1 of [RFC4861] to change
+	the following router configuration variables.
+
+	In §6.2.1, inside the paragraph that defines
+	MaxRtrAdvInterval, change 1800 to 65535 seconds.
+
+	In §6.2.1, inside the paragraph that defines
+	AdvDefaultLifetime, change 9000 to 65535 seconds.
+*/
+#define MaxRtrAdvInterval				65535
+#define MinRtrAdvInterval				3
+#define AdvDefaultLifetime				65535
+/* RFC8319 §4
+	This document updates §4.2 and 6.2.1 of [RFC4861] to change
+	the following router configuration variables.
+
+	In §4.2, inside the paragraph that defines Router Lifetime,
+	change 9000 to 65535 seconds.
+
+	Note: this is 16 bit Router Lifetime field in RA packets
+*/
+#define RouterLifetime					65535
 
 #define ND_RA_FLAG_PROXY		0x4
 #define ND_RA_PREF_HIGH			(1 << 3)

--- a/src/router.h
+++ b/src/router.h
@@ -54,7 +54,18 @@ struct icmpv6_opt {
 
 	Note: this is 16 bit Router Lifetime field in RA packets
 */
-#define RouterLifetime					65535
+/* RFC9096 defines recommended option lifetimes configuration values
+	ND_PREFERRED_LIMIT 2700
+	ND_VALID_LIMIT 5400
+
+	RFC9096  §3.4
+	CE routers SHOULD set the "Router Lifetime" of Router Advertisement
+	(RA) messages to ND_PREFERRED_LIMIT.
+
+	Note: while the RFC recommends SHOULD of ND_PREFERRED_LIMIT, this
+	define is used to cap values to a sane ceiling, i.e. ND_VALID_LIMIT.
+*/
+#define RouterLifetime					5400
 
 #define ND_RA_FLAG_PROXY		0x4
 #define ND_RA_PREF_HIGH			(1 << 3)

--- a/src/router.h
+++ b/src/router.h
@@ -78,6 +78,11 @@ struct icmpv6_opt {
 	Note: this value is an 8 bit int, so max 255.
 */
 #define AdvCurHopLimit					255
+/* RFC4861 §10 - constants
+	Node constants:
+		RETRANS_TIMER                 1,000 milliseconds
+*/
+#define RETRANS_TIMER_MAX				60000
 
 #define ND_RA_FLAG_PROXY		0x4
 #define ND_RA_PREF_HIGH			(1 << 3)

--- a/src/router.h
+++ b/src/router.h
@@ -83,6 +83,12 @@ struct icmpv6_opt {
 		RETRANS_TIMER                 1,000 milliseconds
 */
 #define RETRANS_TIMER_MAX				60000
+/* RFC2460 §5
+   IPv6 requires that every link in the internet have an MTU of 1280
+   octets or greater. 
+*/
+#define RA_MTU_MIN						1280
+#define RA_MTU_MAX						65535
 
 #define ND_RA_FLAG_PROXY		0x4
 #define ND_RA_PREF_HIGH			(1 << 3)


### PR DESCRIPTION
Clamp values read from config to RFC mandated sane values instead of just
complaining.  Fixed also a bug in MTU handling.