### PR TITLE
feat: support multiple mac addresses per static lease

### DIFF
--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -178,7 +178,8 @@ struct lease {
 	struct list_head assignments;
 	uint32_t ipaddr;
 	uint64_t hostid;
-	struct ether_addr mac;
+	struct ether_addr *mac_arr;
+	size_t mac_len;
 	uint16_t duid_len;
 	uint8_t *duid;
 	uint32_t leasetime;


### PR DESCRIPTION
fixes openwrt/odhcpd#221
fixes openwrt/openwrt#9598

Very keen for some feedback on this - my C is pretty rusty but I think the adjustments I've made make sense.

Haven't been able to test this beyond compiling it and giving it a config file to parse (confirmed it works with both the old `option mac` and the new `list mac` formats) but I don't think there's any other changes required to support this.