### PR TITLE
config: support ip=ignore in static leases config

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ and may also receive information from ubus
 ### Sections of type host (static leases)
 | Option		| Type	|Default| Description |
 | :-------------------- | :---- | :---- | :---------- |
-| ip			|string	|(none) | IPv4 host address |
+| ip			|string	|(none) | IPv4 host address or `ignore` to ignore any DHCP request from this host |
 | mac			|list\|string|(none) | HexadecimalMACaddress(es) |
 | duid			|string	|(none)	| HexadecimalDUID |
 | hostid		|string	|(none)	| IPv6hostidentifier |

--- a/src/config.c
+++ b/src/config.c
@@ -516,9 +516,14 @@ int set_lease_from_blobmsg(struct blob_attr *ba)
 			goto err;
 	}
 
-	if ((c = tb[LEASE_ATTR_IP]))
-		if (inet_pton(AF_INET, blobmsg_get_string(c), &l->ipaddr) < 0)
+	if ((c = tb[LEASE_ATTR_IP])) {
+		char *ip_str = blobmsg_get_string(c);
+
+		if (!strcmp(ip_str, "ignore"))
+			l->ignore = true;
+		else if (inet_pton(AF_INET, ip_str, &l->ipaddr) < 0)
 			goto err;
+	}
 
 	if ((c = tb[LEASE_ATTR_HOSTID])) {
 		errno = 0;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1516,7 +1516,8 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 			}
 		}
 
-		if (l && a && a->lease != l) {
+		bool ignored = (l && l->ignore);
+		if (l && a && (a->lease != l || ignored)) {
 			free_assignment(a);
 			a = NULL;
 		}
@@ -1533,7 +1534,7 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 
 			if (!a) {
 				if ((!iface->no_dynamic_dhcp || (l && is_na)) &&
-				    (iface->dhcpv6_pd || iface->dhcpv6_na)) {
+				    (iface->dhcpv6_pd || iface->dhcpv6_na) && !ignored) {
 					/* Create new binding */
 					a = alloc_assignment(clid_len);
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -192,6 +192,7 @@ struct lease {
 	uint8_t *duid;
 	uint32_t leasetime;
 	char *hostname;
+	bool ignore;
 };
 
 enum {


### PR DESCRIPTION
Allows hosts to be ignored from DHCP and makes odhcpd compatible with the configuration as documented here:

https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases

fixes #198