### PR TITLE
ndp: fix macOS IPv6 compatibility by using link-local source addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ and may also receive information from ubus
 | ra_pref64		|string	| -	| Announce PREF64 option for NAT64 prefix (RFC8781) [IPv6 prefix] |
 | ndproxy_routing	|bool	| 1	| Learn routes from NDP |
 | ndproxy_slave		|bool	| 0	| NDProxy external slave |
+| ndp_from_link_local	|bool	| 1	| Use link-local source addresses for NDP operations (RFC 4861, §4.2 compliance) and macOS compatibility |
 | prefix_filter		|string	|`::/0`	| Only advertise on-link prefixes within the provided IPv6 prefix; others are filtered out. [IPv6 prefix] |
 | ntp			|list	|`<local address>`| NTP servers to announce accepts IPv4 and IPv6 |
 

--- a/src/config.c
+++ b/src/config.c
@@ -117,6 +117,7 @@ enum {
 	IFACE_ATTR_PD_CER,
 	IFACE_ATTR_NDPROXY_ROUTING,
 	IFACE_ATTR_NDPROXY_SLAVE,
+	IFACE_ATTR_NDP_FROM_LINK_LOCAL,
 	IFACE_ATTR_PREFIX_FILTER,
 	IFACE_ATTR_MAX_PREFERRED_LIFETIME,
 	IFACE_ATTR_MAX_VALID_LIFETIME,
@@ -171,6 +172,7 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_RA_PREF64] = { .name = "ra_pref64", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_NDPROXY_ROUTING] = { .name = "ndproxy_routing", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_NDPROXY_SLAVE] = { .name = "ndproxy_slave", .type = BLOBMSG_TYPE_BOOL },
+	[IFACE_ATTR_NDP_FROM_LINK_LOCAL] = { .name = "ndp_from_link_local", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_PREFIX_FILTER] = { .name = "prefix_filter", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_MAX_PREFERRED_LIFETIME] = { .name = "max_preferred_lifetime", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_MAX_VALID_LIFETIME] = { .name = "max_valid_lifetime", .type = BLOBMSG_TYPE_STRING },
@@ -271,6 +273,8 @@ static void set_interface_defaults(struct interface *iface)
 	iface->ra = MODE_DISABLED;
 	iface->ndp = MODE_DISABLED;
 	iface->learn_routes = 1;
+	iface->ndp_from_link_local = true;
+	iface->cached_linklocal_valid = false;
 	iface->dhcp_leasetime = 43200;
 	iface->max_preferred_lifetime = ND_PREFERRED_LIMIT;
 	iface->max_valid_lifetime = ND_VALID_LIMIT;
@@ -1450,6 +1454,9 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_NDPROXY_SLAVE]))
 		iface->external = blobmsg_get_bool(c);
+
+	if ((c = tb[IFACE_ATTR_NDP_FROM_LINK_LOCAL]))
+		iface->ndp_from_link_local = blobmsg_get_bool(c);
 
 	if ((c = tb[IFACE_ATTR_PREFIX_FILTER]))
 		odhcpd_parse_addr6_prefix(blobmsg_get_string(c),

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -333,6 +333,9 @@ struct interface {
 
 	// NDP
 	int learn_routes;
+	bool ndp_from_link_local;
+	struct in6_addr cached_linklocal_addr;
+	bool cached_linklocal_valid;
 
 	// RA
 	uint8_t ra_flags;
@@ -469,10 +472,18 @@ int odhcpd_register(struct odhcpd_event *event);
 int odhcpd_deregister(struct odhcpd_event *event);
 void odhcpd_process(struct odhcpd_event *event);
 
+ssize_t odhcpd_send_with_src(int socket, struct sockaddr_in6 *dest,
+		struct iovec *iov, size_t iov_len,
+		const struct interface *iface, const struct in6_addr *src_addr);
 ssize_t odhcpd_send(int socket, struct sockaddr_in6 *dest,
 		struct iovec *iov, size_t iov_len,
 		const struct interface *iface);
+ssize_t odhcpd_try_send_with_src(int socket, struct sockaddr_in6 *dest,
+		struct iovec *iov, size_t iov_len,
+		struct interface *iface);
 int odhcpd_get_interface_dns_addr(const struct interface *iface,
+		struct in6_addr *addr);
+int odhcpd_get_interface_linklocal_addr(struct interface *iface,
 		struct in6_addr *addr);
 int odhcpd_get_interface_config(const char *ifname, const char *what);
 int odhcpd_get_mac(const struct interface *iface, uint8_t mac[6]);


### PR DESCRIPTION
macOS ignores NDP packets that don't originate from link-local addresses,
causing IPv6 connectivity issues with odhcpd. This change ensures NDP
packets (Neighbor Advertisements and ICMP Echo Requests) are sent using
link-local source addresses for RFC 4861 compliance.

Changes:
- Add ndp_from_link_local configuration flag
- Add odhcpd_send_with_src() to allow explicit source address control
- Add odhcpd_get_interface_linklocal_addr() to find link-local addresses
- Update send_na() and ping6() to prefer link-local source addresses when flag is enabled
- Add RFC 4861 section 4.2 comments explaining the mandated behavior
- Maintain backward compatibility with fallback behavior

Fixes: https://github.com/openwrt/openwrt/issues/7561 https://github.com/openwrt/odhcpd/issues/202