### PR TITLE
[RFC9096] Improve section 3.5 SLAAC compliance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ FIND_PATH(ubox_include_dir libubox/uloop.h)
 FIND_PATH(libnl-tiny_include_dir netlink-generic.h PATH_SUFFIXES libnl-tiny)
 INCLUDE_DIRECTORIES(${ubox_include_dir} ${libnl-tiny_include_dir})
 
+FIND_LIBRARY(json NAMES json-c)
 FIND_LIBRARY(libnl NAMES nl-tiny)
 
 add_definitions(-D_GNU_SOURCE -Os -Wall -Werror --std=gnu99)
@@ -37,7 +38,7 @@ if(${DHCPV4_SUPPORT})
 endif(${DHCPV4_SUPPORT})
 
 add_executable(odhcpd src/odhcpd.c src/config.c src/router.c src/dhcpv6.c src/ndp.c src/dhcpv6-ia.c src/dhcpv6-pxe.c src/netlink.c ${EXT_SRC})
-target_link_libraries(odhcpd resolv ubox uci ${libnl} ${EXT_LINK})
+target_link_libraries(odhcpd resolv ubox uci ${json} ${libnl} ${EXT_LINK})
 
 # Installation
 install(TARGETS odhcpd DESTINATION sbin/)

--- a/README
+++ b/README
@@ -67,6 +67,7 @@ leasefile	string				DHCP/v6 lease/hostfile
 leasetrigger	string				Lease trigger script
 hostsfile	string				DHCP/v6 hostfile
 loglevel	integer 6			Syslog level priority (0-7)
+piofile		string				IPv6 RA PIO file
 
 
 Sections of type dhcp (configure DHCP / DHCPv6 / RA / NDP service)

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -49,6 +49,7 @@ static int urandom_fd = -1;
 
 static void sighandler(_unused int signal)
 {
+	config_shutdown();
 	uloop_end();
 }
 

--- a/src/router.h
+++ b/src/router.h
@@ -38,3 +38,5 @@ struct icmpv6_opt {
 #define ND_RA_FLAG_PROXY		0x4
 #define ND_RA_PREF_HIGH			(1 << 3)
 #define ND_RA_PREF_LOW			(3 << 3)
+
+#define LT_DIFF_TH			10


### PR DESCRIPTION
[RFC9096 § 3.5](https://datatracker.ietf.org/doc/html/rfc9096#section-3.5)

When a CE router provides LAN-side address-configuration information
via SLAAC:

*  A CE router sending RAs that advertise prefixes belonging to a
   dynamically learned prefix (e.g., via DHCPv6-PD) SHOULD record, on
   stable storage, the list of prefixes being advertised via PIOs on
   each network segment and the state of the "A" and "L" flags of the
   corresponding PIOs.

*  Upon changes to the advertised prefixes, and after bootstrapping,
   the CE router advertising prefix information via SLAAC proceeds as
   follows:

   -  Any prefixes that were previously advertised by the CE router
      via PIOs in RA messages, but that have now become stale, MUST
      be advertised with PIOs that have the "Valid Lifetime" and the
      "Preferred Lifetime" set to 0 and the "A" and "L" bits
      unchanged.

   -  The aforementioned advertisements MUST be performed for at
      least the "Valid Lifetime" previously employed for such
      prefixes.

---

The current implementation of this PR should be set with a `piofile` in `/tmp` by default (for example `/tmp/odhcpd-rfc9096`) and then let the users decide if they want to use a file in the flash to comply with RFC9096 on reboots.
Right now, there's a flash write every 12h per interface with IPv6 RA enabled. This is due to the fact that even though the prefix delegated has a validity of 24h, it's renewed at half of that validity.
Different interfaces renewals are spread in time and therefore can't be grouped into a single write with the current implementation:

```
Wed Sep  3 17:51:39 2025 daemon.warn odhcpd[31802]: rfc9096: br-lan: renew 2a02:9142:XXXX:a200::/64 (43193 -> 86393)
Wed Sep  3 17:51:44 2025 daemon.warn odhcpd[31802]: rfc9096: update piofile: /etc/odhcpd-rfc9096
Wed Sep  3 17:55:21 2025 daemon.warn odhcpd[31802]: rfc9096: eth1.10: renew 2a02:9142:XXXX:a210::/64 (42971 -> 86171)
Wed Sep  3 17:55:26 2025 daemon.warn odhcpd[31802]: rfc9096: update piofile: /etc/odhcpd-rfc9096
```

```
Thu Sep  4 05:51:55 2025 daemon.warn odhcpd[31802]: rfc9096: br-lan: renew 2a02:9142:XXXX:a200::/64 (43177 -> 86380)
Thu Sep  4 05:52:00 2025 daemon.warn odhcpd[31802]: rfc9096: update piofile: /etc/odhcpd-rfc9096
Thu Sep  4 05:54:21 2025 daemon.warn odhcpd[31802]: rfc9096: eth1.10: renew 2a02:9142:XXXX:a210::/64 (43030 -> 86233)
Thu Sep  4 05:54:26 2025 daemon.warn odhcpd[31802]: rfc9096: update piofile: /etc/odhcpd-rfc9096
```

```
Thu Sep  4 17:52:03 2025 daemon.warn odhcpd[31802]: rfc9096: br-lan: renew 2a02:9142:XXXX:a200::/64 (43172 -> 86375)
Thu Sep  4 17:52:08 2025 daemon.warn odhcpd[31802]: rfc9096: update piofile: /etc/odhcpd-rfc9096
Thu Sep  4 17:59:23 2025 daemon.warn odhcpd[31802]: rfc9096: eth1.10: renew 2a02:9142:XXXX:a210::/64 (42732 -> 85935)
Thu Sep  4 17:59:28 2025 daemon.warn odhcpd[31802]: rfc9096: update piofile: /etc/odhcpd-rfc9096
```

```
Fri Sep  5 05:52:12 2025 daemon.warn odhcpd[31802]: rfc9096: br-lan: renew 2a02:9142:XXXX:a200::/64 (43165 -> 86367)
Fri Sep  5 05:52:17 2025 daemon.warn odhcpd[31802]: rfc9096: update piofile: /etc/odhcpd-rfc9096
Fri Sep  5 05:54:09 2025 daemon.warn odhcpd[31802]: rfc9096: eth1.10: renew 2a02:9142:XXXX:a210::/64 (43049 -> 86251)
Fri Sep  5 05:54:16 2025 daemon.warn odhcpd[31802]: rfc9096: update piofile: /etc/odhcpd-rfc9096
```