### PR TITLE
odhcpd: support multiple per-client MAC addresses

### DIFF
--- a/README
+++ b/README
@@ -161,13 +161,13 @@ ntp			list	<local address>		NTP servers to announce
 
 
 Sections of type host (static leases)
-Option		Type	Default			Description
-ip		string				IP-Address to lease
-mac		string				MAC-address
-duid		string				DUID in base16
-hostid		string				IPv6 host identifier
-name		string				Hostname
-leasetime	string				DHCPv4/v6 leasetime
+Option		Type		Default			Description
+ip		string		(none)			IPv4 host address
+mac		list|string	(none)			Hexadecimal MAC address(es)
+duid		string		(none)			Hexadecimal DUID
+hostid		string		(none)			IPv6 host identifier
+name		string		(none)			Hostname
+leasetime	string		(none)			DHCPv4/v6 leasetime
 
 Sections of type boot6
 Option		Type	Required		Description

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -178,7 +178,8 @@ struct lease {
 	struct list_head assignments;
 	uint32_t ipaddr;
 	uint64_t hostid;
-	struct ether_addr mac;
+	size_t mac_count;
+	struct ether_addr *macs;
 	uint16_t duid_len;
 	uint8_t *duid;
 	uint32_t leasetime;


### PR DESCRIPTION
Allow the configuration of multiple per-client DHCPv4 MAC addresses. This is for feature parity with dnsmasq.

Closes: https://github.com/openwrt/odhcpd/issues/221
Closes: https://github.com/openwrt/openwrt/issues/9598