### PR TITLE
odhcpd: bump minimum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0015 NEW)
 
 # Project Definition


### PR DESCRIPTION
This removes warnings with more recent versions of cmake.

3.13 is already required by e.g. ubus, so it seems like a reasonable minimum.