### PR TITLE
odhcpd: allow multiple DUIDs per static lease, allow matching leases on IAID

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ and may also receive information from ubus
 | :-------------------- | :---- | :---- | :---------- |
 | ip			|string	|(none) | IPv4 host address |
 | mac			|list\|string|(none) | HexadecimalMACaddress(es) |
-| duid			|string |(none) | Hexadecimal DUID, or DUID%IAID |
+| duid			|list\|string|(none) | Hexadecimal DUID(s), or DUID%IAID(s) |
 | hostid		|string	|(none)	| IPv6hostidentifier |
 | name			|string	|(none) | Hostname |
 | leasetime		|string	|(none) | DHCPv4/v6leasetime |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ and may also receive information from ubus
 | :-------------------- | :---- | :---- | :---------- |
 | ip			|string	|(none) | IPv4 host address |
 | mac			|list\|string|(none) | HexadecimalMACaddress(es) |
-| duid			|string	|(none)	| HexadecimalDUID |
+| duid			|string |(none) | Hexadecimal DUID, or DUID%IAID |
 | hostid		|string	|(none)	| IPv6hostidentifier |
 | name			|string	|(none) | Hostname |
 | leasetime		|string	|(none) | DHCPv4/v6leasetime |

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -180,6 +180,8 @@ struct config {
 	int log_level;
 };
 
+/* 2-byte type + 128-byte DUID, RFC8415, §11.1 */
+#define DUID_MAX_LEN 130
 
 struct lease {
 	struct vlist_node node;
@@ -190,6 +192,8 @@ struct lease {
 	struct ether_addr *macs;
 	uint16_t duid_len;
 	uint8_t *duid;
+	uint32_t iaid;
+	bool iaid_set;
 	uint32_t leasetime;
 	char *hostname;
 };

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -184,6 +184,13 @@ struct config {
 #define DUID_MAX_LEN 130
 #define DUID_HEXSTRLEN (DUID_MAX_LEN * 2 + 1)
 
+struct duid {
+	uint8_t len;
+	uint8_t id[DUID_MAX_LEN];
+	uint32_t iaid;
+	bool iaid_set;
+};
+
 struct lease {
 	struct vlist_node node;
 	struct list_head assignments;
@@ -191,10 +198,8 @@ struct lease {
 	uint64_t hostid;
 	size_t mac_count;
 	struct ether_addr *macs;
-	uint16_t duid_len;
-	uint8_t *duid;
-	uint32_t iaid;
-	bool iaid_set;
+	size_t duid_count;
+	struct duid *duids;
 	uint32_t leasetime;
 	char *hostname;
 };

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -182,6 +182,7 @@ struct config {
 
 /* 2-byte type + 128-byte DUID, RFC8415, §11.1 */
 #define DUID_MAX_LEN 130
+#define DUID_HEXSTRLEN (DUID_MAX_LEN * 2 + 1)
 
 struct lease {
 	struct vlist_node node;
@@ -510,7 +511,8 @@ bool odhcpd_bitlen2netmask(bool v6, unsigned int bits, void *mask);
 bool odhcpd_valid_hostname(const char *name);
 
 int config_parse_interface(void *data, size_t len, const char *iname, bool overwrite);
-struct lease *config_find_lease_by_duid(const uint8_t *duid, const uint16_t len);
+struct lease *config_find_lease_by_duid_and_iaid(const uint8_t *duid, const uint16_t len,
+						 const uint32_t iaid);
 struct lease *config_find_lease_by_mac(const uint8_t *mac);
 struct lease *config_find_lease_by_hostid(const uint64_t hostid);
 struct lease *config_find_lease_by_ipaddr(const uint32_t ipaddr);


### PR DESCRIPTION
The details are in each commit, but essentially this patch series allows static leases to be defined via `<DUID>%<IAID>` as an alternative to plain `<DUID>` hex strings.

In addition, support for several DUIDs per static lease (similar to the recently merged multiple-MAC address support in c9816de148cc3e8096e67519d2c081ffeb9b4857) has been implemented.

Related topics:
https://github.com/openwrt/odhcpd/issues/175
https://github.com/openwrt/luci/pull/7946
