### PR TITLE
odhcpd: allow the use of an alternative cfg file

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -39,6 +39,7 @@ struct config config = {
 	.dhcp_hostsfile = NULL,
 	.ra_piofolder = NULL,
 	.ra_piofolder_fd = -1,
+	.uci_cfgfile = "dhcp",
 	.log_level = LOG_WARNING,
 };
 
@@ -2038,7 +2039,7 @@ void odhcpd_reload(void)
 		clean_interface(i);
 
 	struct uci_package *dhcp = NULL;
-	if (!uci_load(uci, "dhcp", &dhcp)) {
+	if (!uci_load(uci, config.uci_cfgfile, &dhcp)) {
 		struct uci_element *e;
 
 		/* 1. Global settings */

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -54,12 +54,12 @@ static void sighandler(_unused int signal)
 
 static void print_usage(const char *app)
 {
-	printf(
-	"== %s Usage ==\n\n"
-	"  -h, --help   Print this help\n"
-	"  -l level     Specify log level 0..7 (default %d)\n",
-		app, config.log_level
-	);
+	printf("== %s Usage ==\n"
+	       "\n"
+	       "	-c <path>	Use an alternative configuration file\n"
+	       "	-l <int>	Specify log level 0..7 (default %d)\n"
+	       "	-h		Print this help text and exit\n",
+	       app, config.log_level);
 }
 
 static bool ipv6_enabled(void)
@@ -79,15 +79,19 @@ int main(int argc, char **argv)
 	openlog("odhcpd", LOG_PERROR | LOG_PID, LOG_DAEMON);
 	int opt;
 
-	while ((opt = getopt(argc, argv, "hl:")) != -1) {
+	while ((opt = getopt(argc, argv, "c:l:h")) != -1) {
 		switch (opt) {
-		case 'h':
-			print_usage(argv[0]);
-			return 0;
+		case 'c':
+			config.uci_cfgfile = realpath(optarg, NULL);
+			fprintf(stderr, "Configuration will be read from %s\n", config.uci_cfgfile);
+			break;
 		case 'l':
 			config.log_level = (atoi(optarg) & LOG_PRIMASK);
 			fprintf(stderr, "Log level set to %d\n", config.log_level);
 			break;
+		case 'h':
+			print_usage(argv[0]);
+			return 0;
 		}
 	}
 	setlogmask(LOG_UPTO(config.log_level));

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -176,6 +176,7 @@ struct config {
 	char *ra_piofolder;
 	int ra_piofolder_fd;
 
+	char *uci_cfgfile;
 	int log_level;
 };
 


### PR DESCRIPTION
This is mainly useful for development/testing, since it obviates the need for a cfg file below the /etc hierarchy.

Also, fixup the help message (long options like "--help" are not supported).