### PR TITLE
odhcpd: update cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,58 +1,92 @@
 cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0015 NEW)
 
+
 # Project Definition
-project(odhcpd C)
-
-set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3 -std=gnu99")
-
-FIND_PATH(ubox_include_dir libubox/uloop.h)
-FIND_PATH(libnl-tiny_include_dir netlink-generic.h PATH_SUFFIXES libnl-tiny)
-INCLUDE_DIRECTORIES(${ubox_include_dir} ${libnl-tiny_include_dir})
-
-FIND_LIBRARY(json NAMES json-c)
-FIND_LIBRARY(libnl NAMES nl-tiny)
-
-add_definitions(-D_GNU_SOURCE -Os -Wall -Werror --std=gnu99)
-IF(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
-	add_definitions(-Wextra -Werror=implicit-function-declaration)
-	add_definitions(-Wformat -Werror=format-security -Werror=format-nonliteral)
-ENDIF()
-add_definitions(-Wno-unused-parameter -Wmissing-declarations)
+project(odhcpd LANGUAGES C)
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE
+	src/odhcpd.c
+	src/config.c
+	src/dhcpv6.c
+	src/dhcpv6-ia.c
+	src/dhcpv6-pxe.c
+	src/ndp.c
+	src/netlink.c
+	src/router.c
+)
 
 
+# Compiler Options
+set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 11)
+target_compile_definitions(${PROJECT_NAME} PRIVATE _GNU_SOURCE)
+target_compile_options(${PROJECT_NAME} PRIVATE -g3)
+target_compile_options(${PROJECT_NAME} PRIVATE -Os)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wextra)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror=implicit-function-declaration)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wformat)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror=format-security)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror=format-nonliteral)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wno-unused-parameter)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wmissing-declarations)
+
+
+# Libraries
+target_link_libraries(${PROJECT_NAME} PRIVATE resolv)
+
+find_path(uci_include_dir uci.h)
+target_include_directories(${PROJECT_NAME} PRIVATE ${uci_include_dir})
+find_library(libuci uci)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${libuci})
+
+find_path(ubox_include_dir uloop.h PATH_SUFFIXES libubox)
+target_include_directories(${PROJECT_NAME} PRIVATE ${ubox_include_dir})
+find_library(libubox ubox)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${libubox})
+
+find_path(libnl-tiny_include_dir netlink-generic.h PATH_SUFFIXES libnl-tiny)
+target_include_directories(${PROJECT_NAME} PRIVATE ${libnl-tiny_include_dir})
+find_library(libnl nl-tiny)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${libnl})
+
+find_path(json_include_dir json.h PATH_SUFFIXES json-c)
+target_include_directories(${PROJECT_NAME} PRIVATE ${json_include_dir})
+find_library(libjson json-c)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${libjson})
+
+
+# Optional Features
 if (${EXT_CER_ID})
-	add_definitions(-DEXT_CER_ID=${EXT_CER_ID})
+	target_compile_definitions(${PROJECT_NAME} PRIVATE EXT_CER_ID=${EXT_CER_ID})
 endif(${EXT_CER_ID})
 
 if(${UBUS})
-	add_definitions(-DWITH_UBUS)
-	set(EXT_SRC ${EXT_SRC} src/ubus.c)
-	set(EXT_LINK ${EXT_LINK} ubus)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE WITH_UBUS)
+	target_sources(${PROJECT_NAME} PRIVATE src/ubus.c)
+	find_path(ubus_include_dir libubus.h)
+	target_include_directories(${PROJECT_NAME} PRIVATE ${ubus_include_dir})
+	find_library(libubus ubus)
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${libubus})
 endif(${UBUS})
 
 if(${DHCPV4_SUPPORT})
-	add_definitions(-DDHCPV4_SUPPORT)
-	set(EXT_SRC ${EXT_SRC} src/dhcpv4.c)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE DHCPV4_SUPPORT)
+	target_sources(${PROJECT_NAME} PRIVATE src/dhcpv4.c)
 endif(${DHCPV4_SUPPORT})
 
-add_executable(odhcpd src/odhcpd.c src/config.c src/router.c src/dhcpv6.c src/ndp.c src/dhcpv6-ia.c src/dhcpv6-pxe.c src/netlink.c ${EXT_SRC})
-target_link_libraries(odhcpd resolv ubox uci ${json} ${libnl} ${EXT_LINK})
 
 # Installation
-install(TARGETS odhcpd DESTINATION sbin/)
+install(TARGETS ${PROJECT_NAME} DESTINATION sbin/)
 
 
-# Packaging information
+# Packaging Information
 set(CPACK_PACKAGE_VERSION "1")
 set(CPACK_PACKAGE_CONTACT "Steven Barth <steven@midlink.org>")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "odhcpd")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PROJECT_NAME}")
 set(CPACK_GENERATOR "DEB;RPM;STGZ")
 set(CPACK_STRIP_FILES true)
-
-SET(CPACK_DEBIAN_PACKAGE_VERSION ${CPACK_PACKAGE_VERSION})
+set(CPACK_DEBIAN_PACKAGE_VERSION ${CPACK_PACKAGE_VERSION})
 set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}_${CPACK_DEBIAN_PACKAGE_VERSION}")
-
 include(CPack)
-


### PR DESCRIPTION
Now that the minimum cmake version has been bumped to 3.13, the cmake file can be modernized a bit. Although it might look like a lot of changes, most of them are quite straightforward.

Every library is located in a consistent manner (allowing command-line overrides of library locations, useful for local development, and also makes it trivial to do static linking, if desired).

The compiler flags have been broken up to have one per line (making it easy in the future to add/remove flags, which would create a simple one-line diff).

Although it might look like this bumps the C standard level, cmake is actually smart enough to pick an earlier version if C11 isn't supported by the compiler (quite unlikely on any versions of gcc currently in use in OpenWrt and even on old distros).