### PR TITLE
odhcpd: remove confusing #defines

### DIFF
--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -218,12 +218,10 @@ struct dhcp_assignment {
 	time_t valid_until;
 	time_t preferred_until;
 
-#define fr_timer	reconf_timer
-	struct uloop_timeout reconf_timer;
-#define accept_fr_nonce accept_reconf
-	bool accept_reconf;
-#define fr_cnt		reconf_cnt
-	int reconf_cnt;
+	// ForceRenew - RFC6704 §3.1.2 (IPv4), RFC8415 (IPv6), §20.4, §21.11
+	struct uloop_timeout fr_timer;
+	bool accept_fr_nonce;
+	int fr_cnt;
 	uint8_t key[16];
 	struct odhcpd_ref_ip *fr_ip;
 
@@ -245,8 +243,7 @@ struct dhcp_assignment {
 	uint8_t *reqopts;
 	size_t reqopts_len;
 
-#define hwaddr		mac
-	uint8_t mac[6];
+	uint8_t hwaddr[6];
 
 	uint16_t clid_len;
 	uint8_t clid_data[];

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -143,7 +143,7 @@ static int handle_dhcpv6_leases(_unused struct ubus_context *ctx, _unused struct
 
 			blobmsg_add_u32(&b, "iaid", ntohl(a->iaid));
 			blobmsg_add_string(&b, "hostname", (a->hostname) ? a->hostname : "");
-			blobmsg_add_u8(&b, "accept-reconf", a->accept_reconf);
+			blobmsg_add_u8(&b, "accept-reconf", a->accept_fr_nonce);
 			if (a->flags & OAF_DHCPV6_NA)
 				blobmsg_add_u64(&b, "assigned", a->assigned_host_id);
 			else


### PR DESCRIPTION
Right now, odhcpd.h contains lines like `#define hwaddr mac`, which is a great footgun when hacking on odhcpd (like when creating a function with a local variable named `hwaddr` and later getting compiler errors talking about how `mac` has the wrong type...in a function which has no variable named `mac`).

So, remove these definitions. I'm not sure the chosen variable names are the most descriptive, but I erred on the side of caution and picked the alternative that required the least amount of changes. We can always change the names of the variables later.