### PR TITLE
[WIP] dhcp[46]: Support custom options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ and may also receive information from ubus
 | dhcpv6_pd		|bool	| 1	| DHCPv6 stateful addressing hands out IA_PD - Internet Address - Prefix Delegation |
 | dhcpv6_pd_min_len	|integer| -	| Minimum prefix length to delegate with IA_PD (value is adjusted if needed to be greater than the interface prefix length).  Range [1,62] |
 | dhcpv6_option		|list	| -	| Custom DHCPv6 options in the form of strings formatted as `<optcode>,<encoding>:<data>`. For example: `42,hex:4575726F70652F4265726C696E` (timezone = "Europe/Berlin", RFC4833, §3) |
+| dhcpv4_option		|list	| -	| Custom DHCPv4 options in the same format |
 | router		|list	|`<local address>`| Routers to announce, accepts IPv4 only |
 | dns			|list	|`<local address>`| DNS servers to announce, accepts IPv4 and IPv6 |
 | dnr			|list	|disabled| Encrypted DNS servers to announce, `<priority> <domain name> [<comma separated IP addresses> <SvcParams (key=value)>...]` |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ and may also receive information from ubus
 | dhcpv6_na		|bool	| 1	| DHCPv6 stateful addressing hands out IA_NA - Internet Address - Network Address |
 | dhcpv6_pd		|bool	| 1	| DHCPv6 stateful addressing hands out IA_PD - Internet Address - Prefix Delegation |
 | dhcpv6_pd_min_len	|integer| -	| Minimum prefix length to delegate with IA_PD (value is adjusted if needed to be greater than the interface prefix length).  Range [1,62] |
+| dhcpv6_option		|list	| -	| Custom DHCPv6 options in the form of strings formatted as `<optcode>,<encoding>:<data>`. For example: `42,hex:4575726F70652F4265726C696E` (timezone = "Europe/Berlin", RFC4833, §3) |
 | router		|list	|`<local address>`| Routers to announce, accepts IPv4 only |
 | dns			|list	|`<local address>`| DNS servers to announce, accepts IPv4 and IPv6 |
 | dnr			|list	|disabled| Encrypted DNS servers to announce, `<priority> <domain name> [<comma separated IP addresses> <SvcParams (key=value)>...]` |

--- a/src/config.c
+++ b/src/config.c
@@ -97,6 +97,7 @@ enum {
 	IFACE_ATTR_DHCPV6_PD_MIN_LEN,
 	IFACE_ATTR_DHCPV6_NA,
 	IFACE_ATTR_DHCPV6_HOSTID_LEN,
+	IFACE_ATTR_DHCPV6_OPTION,
 	IFACE_ATTR_RA_DEFAULT,
 	IFACE_ATTR_RA_MANAGEMENT,
 	IFACE_ATTR_RA_FLAGS,
@@ -151,6 +152,7 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_DHCPV6_PD_MIN_LEN] = { .name = "dhcpv6_pd_min_len", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_DHCPV6_NA] = { .name = "dhcpv6_na", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_DHCPV6_HOSTID_LEN] = { .name = "dhcpv6_hostidlength", .type = BLOBMSG_TYPE_INT32 },
+	[IFACE_ATTR_DHCPV6_OPTION] = { .name = "dhcpv6_option", .type = BLOBMSG_TYPE_ARRAY },
 	[IFACE_ATTR_PD_MANAGER] = { .name = "pd_manager", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_PD_CER] = { .name = "pd_cer", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_RA_DEFAULT] = { .name = "ra_default", .type = BLOBMSG_TYPE_INT32 },
@@ -281,6 +283,8 @@ static void set_interface_defaults(struct interface *iface)
 	iface->dhcpv6_pd_min_len = 0;
 	iface->dhcpv6_na = true;
 	iface->dhcpv6_hostid_len = HOSTID_LEN_DEFAULT;
+	iface->dhcpv6_options = NULL;
+	iface->dhcpv6_option_cnt = 0;
 	iface->dns_service = true;
 	iface->ra_flags = ND_RA_FLAG_OTHER;
 	iface->ra_slaac = true;
@@ -303,6 +307,9 @@ static void clean_interface(struct interface *iface)
 	free(iface->dhcpv4_ntp);
 	free(iface->dhcpv6_ntp);
 	free(iface->dhcpv6_sntp);
+	for (unsigned i = 0; i < iface->dhcpv6_option_cnt; i++)
+		free(iface->dhcpv6_options[i]);
+	free(iface->dhcpv6_options);
 	for (unsigned i = 0; i < iface->dnr_cnt; i++) {
 		free(iface->dnr[i].adn);
 		free(iface->dnr[i].addr4);
@@ -1268,6 +1275,56 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
 				iface_attrs[IFACE_ATTR_DHCPV6_HOSTID_LEN].name, iface->name);
 
+	}
+
+	if ((c = tb[IFACE_ATTR_DHCPV6_OPTION])) {
+		int opt_count;
+
+		opt_count = blobmsg_check_array_len(c, BLOBMSG_TYPE_STRING, blob_raw_len(c));
+		if (opt_count > 0) {
+			struct blob_attr *cur;
+			size_t rem;
+
+			iface->dhcpv6_option_cnt = 0;
+			iface->dhcpv6_options = realloc(iface->dhcpv6_options, opt_count * sizeof(*iface->dhcpv6_options));
+			blobmsg_for_each_attr(cur, c, rem) {
+				const char *opt_data;
+				char *opt_code_end;
+				unsigned long opt_code;
+				size_t opt_len;
+				struct dhcpv6_option *opt;
+
+				/* syntax: <code>,<encoding>:<data> */
+				opt_data = strchr(blobmsg_get_string(cur), ',');
+				if (!opt_data)
+					goto err_option;
+
+				opt_code = strtoul(blobmsg_get_string(cur), &opt_code_end, 10);
+				if (opt_code < 1 || opt_code > UINT16_MAX || opt_code_end != opt_data)
+					goto err_option;
+
+				opt_data++;
+				if (strncmp(opt_data, "hex:", strlen("hex:")))
+					goto err_option;
+
+				opt_data += strlen("hex:");
+				opt_len = strlen(opt_data);
+				if (opt_len % 2 || opt_len / 2 > UINT16_MAX)
+					goto err_option;
+
+				opt_len /= 2;
+				opt = malloc(sizeof(*opt) + opt_len);
+				opt->code = opt_code;
+				opt->length = opt_len;
+				odhcpd_unhexlify(opt->data, opt_len, opt_data);
+				iface->dhcpv6_options[iface->dhcpv6_option_cnt++] = opt;
+				continue;
+
+			err_option:
+				syslog(LOG_ERR, "Invalid %s value configured for interface '%s'",
+				       iface_attrs[IFACE_ATTR_DHCPV6_OPTION].name, iface->name);
+			}
+		}
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_DEFAULT]))

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -871,6 +871,18 @@ void dhcpv4_handle_msg(void *addr, void *data, size_t len,
 			dhcpv4_put(&reply, &cookie, DHCPV4_OPT_DNR,
 				   dnrs_len, dnrs);
 			break;
+
+		default:
+			for (size_t i = 0; i < iface->dhcpv4_option_cnt; i++) {
+				if (iface->dhcpv4_options[i]->type != a->reqopts[opt])
+					continue;
+				dhcpv4_put(&reply, &cookie,
+					   iface->dhcpv4_options[i]->type,
+					   iface->dhcpv4_options[i]->len,
+					   iface->dhcpv4_options[i]->data);
+				break;
+			}
+			break;
 		}
 	}
 

--- a/src/dhcpv4.h
+++ b/src/dhcpv4.h
@@ -91,12 +91,6 @@ struct dhcpv4_auth_forcerenew {
 	uint8_t key[16];
 } _packed;
 
-struct dhcpv4_option {
-	uint8_t type;
-	uint8_t len;
-	uint8_t data[];
-};
-
 /* DNR */
 struct dhcpv4_dnr {
 	uint16_t len;
@@ -104,7 +98,6 @@ struct dhcpv4_dnr {
 	uint8_t adn_len;
 	uint8_t body[];
 };
-
 
 #define dhcpv4_for_each_option(start, end, opt)\
 	for (opt = (struct dhcpv4_option*)(start); \

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -277,13 +277,19 @@ struct dhcpv6_option {
 	uint8_t data[];
 };
 
+// Generic DHCPv4 option
+struct dhcpv4_option {
+	uint8_t type;
+	uint8_t len;
+	uint8_t data[];
+};
+
 // RA PIO - RFC9096
 struct ra_pio {
 	struct in6_addr prefix;
 	uint8_t length;
 	time_t lifetime;
 };
-
 
 struct interface {
 	struct avl_node avl;
@@ -381,6 +387,8 @@ struct interface {
 	struct in_addr *dhcpv4_dns;
 	size_t dhcpv4_dns_cnt;
 	bool dhcpv4_forcereconf;
+	struct dhcpv4_option **dhcpv4_options;
+	size_t dhcpv4_option_cnt;
 
 	// DNS
 	struct in6_addr *dns;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -270,6 +270,12 @@ struct dnr_options {
 	uint16_t svc_len;
 };
 
+// Generic DHCPv6 option
+struct dhcpv6_option {
+	uint16_t code;
+	uint16_t length;
+	uint8_t data[];
+};
 
 // RA PIO - RFC9096
 struct ra_pio {
@@ -390,6 +396,8 @@ struct interface {
 	bool dhcpv6_na;
 	uint32_t dhcpv6_hostid_len;
 	uint32_t dhcpv6_pd_min_len; // minimum delegated prefix length
+	struct dhcpv6_option **dhcpv6_options;
+	size_t dhcpv6_option_cnt;
 
 	char *upstream;
 	size_t upstream_len;


### PR DESCRIPTION
This adds more feature parity with `dnsmasq` by allowing custom DHCPv4/DHCPv6 options to be set.

WIP so far, needs more testing and the option parsing could be merged for the v4/v6 cases.