### PR TITLE
dhcpv4: cleanup part 1

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -329,7 +329,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 	uint32_t count = end - start + 1;
 	uint32_t seed = 0;
 	bool assigned;
-	char buf[INET_ADDRSTRLEN];
+	char ipv4_str[INET_ADDRSTRLEN];
 
 	/* Preconfigured IP address by static lease */
 	if (a->addr) {
@@ -338,7 +338,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 
 		if (assigned)
 			syslog(LOG_DEBUG, "Assigning static IP: %s",
-			       inet_ntop(AF_INET, &a->addr, buf, sizeof(buf)));
+			       inet_ntop(AF_INET, &a->addr, ipv4_str, sizeof(ipv4_str)));
 
 		return assigned;
 	}
@@ -351,7 +351,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 
 		if (assigned) {
 			syslog(LOG_DEBUG, "Assigning the IP the client asked for: %s",
-			       inet_ntop(AF_INET, &a->addr, buf, sizeof(buf)));
+			       inet_ntop(AF_INET, &a->addr, ipv4_str, sizeof(ipv4_str)));
 			return true;
 		}
 	}
@@ -377,7 +377,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 
 		if (assigned) {
 			syslog(LOG_DEBUG, "Assigning mapped IP: %s (try %u of %u)",
-			       inet_ntop(AF_INET, &a->addr, buf, sizeof(buf)),
+			       inet_ntop(AF_INET, &a->addr, ipv4_str, sizeof(ipv4_str)),
 			       i + 1, count);
 
 			return true;

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -749,17 +749,6 @@ static bool dhcpv4_insert_assignment(struct list_head *list, struct dhcp_assignm
 	return true;
 }
 
-static char* ip4toa(uint32_t addr)
-{
-	static char buf[16];
-
-	snprintf(buf, sizeof(buf), "%u.%u.%u.%u",
-		((uint8_t *)&addr)[0], ((uint8_t *)&addr)[1],
-		((uint8_t *)&addr)[2], ((uint8_t *)&addr)[3]);
-
-	return buf;
-}
-
 static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 			  uint32_t raddr)
 {
@@ -768,6 +757,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 	uint32_t count = end - start + 1;
 	uint32_t seed = 0;
 	bool assigned;
+	char buf[INET_ADDRSTRLEN];
 
 	/* Preconfigured IP address by static lease */
 	if (a->addr) {
@@ -775,7 +765,8 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 						    a, a->addr);
 
 		if (assigned)
-			syslog(LOG_DEBUG, "Assigning static IP: %s", ip4toa(a->addr));
+			syslog(LOG_DEBUG, "Assigning static IP: %s",
+			       inet_ntop(AF_INET, &a->addr, buf, sizeof(buf)));
 
 		return assigned;
 	}
@@ -788,8 +779,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 
 		if (assigned) {
 			syslog(LOG_DEBUG, "Assigning the IP the client asked for: %s",
-			       ip4toa(a->addr));
-
+			       inet_ntop(AF_INET, &a->addr, buf, sizeof(buf)));
 			return true;
 		}
 	}
@@ -815,7 +805,8 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 
 		if (assigned) {
 			syslog(LOG_DEBUG, "Assigning mapped IP: %s (try %u of %u)",
-			       ip4toa(a->addr), i + 1, count);
+			       inet_ntop(AF_INET, &a->addr, buf, sizeof(buf)),
+			       i + 1, count);
 
 			return true;
 		}

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -40,8 +40,6 @@
 				 DHCPV4_MIN_PACKET_SIZE : (uint8_t *)end - (uint8_t *)start)
 #define MAX_PREFIX_LEN 28
 
-static void dhcpv4_fr_rand_delay(struct dhcp_assignment *a);
-
 static uint32_t serial = 0;
 
 struct odhcpd_ref_ip {
@@ -269,6 +267,8 @@ static void dhcpv4_fr_start(struct dhcp_assignment *a)
 
 	dhcpv4_fr_send(a);
 }
+
+static void dhcpv4_fr_rand_delay(struct dhcp_assignment *a);
 
 static void dhcpv4_fr_delay_timer(struct uloop_timeout *event)
 {

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1155,7 +1155,7 @@ out:
 	return ret;
 }
 
-static void handle_addrlist_change(struct interface *iface)
+static void dhcpv4_addrlist_change(struct interface *iface)
 {
 	struct odhcpd_ipaddr ip;
 	struct odhcpd_ref_ip *a;
@@ -1208,7 +1208,7 @@ static void dhcpv4_netevent_cb(unsigned long event, struct netevent_handler_info
 		dhcpv4_setup_interface(iface, true);
 		break;
 	case NETEV_ADDRLIST_CHANGE:
-		handle_addrlist_change(iface);
+		dhcpv4_addrlist_change(iface);
 		break;
 	default:
 		break;

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -151,12 +151,6 @@ static char *dhcpv4_msg_to_string(uint8_t reqmsg)
 	}
 }
 
-static void dhcpv4_free_assignment(struct dhcp_assignment *a)
-{
-	if (a->fr_ip)
-		dhcpv4_fr_stop(a);
-}
-
 static void dhcpv4_put(struct dhcpv4_message *msg, uint8_t **cookie,
 		uint8_t type, uint8_t len, const void *data)
 {
@@ -724,6 +718,12 @@ static void dhcpv4_handle_dgram(void *addr, void *data, size_t len,
 	int sock = iface->dhcpv4_event.uloop.fd;
 
 	dhcpv4_handle_msg(addr, data, len, iface, dest_addr, dhcpv4_send_reply, &sock);
+}
+
+static void dhcpv4_free_assignment(struct dhcp_assignment *a)
+{
+	if (a->fr_ip)
+		dhcpv4_fr_stop(a);
 }
 
 static bool dhcpv4_insert_assignment(struct list_head *list, struct dhcp_assignment *a,

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -50,17 +50,6 @@ struct odhcpd_ref_ip {
 	struct odhcpd_ipaddr addr;
 };
 
-static struct dhcp_assignment *find_assignment_by_hwaddr(struct interface *iface, const uint8_t *hwaddr)
-{
-	struct dhcp_assignment *a;
-
-	list_for_each_entry(a, &iface->dhcpv4_assignments, head)
-		if (!memcmp(a->hwaddr, hwaddr, 6))
-			return a;
-
-	return NULL;
-}
-
 static void inc_ref_cnt_ip(struct odhcpd_ref_ip **ptr, struct odhcpd_ref_ip *ip)
 {
 	*ptr = ip;
@@ -400,6 +389,16 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 	return false;
 }
 
+static struct dhcp_assignment *find_assignment_by_hwaddr(struct interface *iface, const uint8_t *hwaddr)
+{
+	struct dhcp_assignment *a;
+
+	list_for_each_entry(a, &iface->dhcpv4_assignments, head)
+		if (!memcmp(a->hwaddr, hwaddr, 6))
+			return a;
+
+	return NULL;
+}
 
 static struct dhcp_assignment*
 dhcpv4_lease(struct interface *iface, enum dhcpv4_msg msg, const uint8_t *mac,

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1218,7 +1218,7 @@ static void dhcpv4_netevent_cb(unsigned long event, struct netevent_handler_info
 	}
 }
 
-static void valid_until_cb(struct uloop_timeout *event)
+static void dhcpv4_valid_until_cb(struct uloop_timeout *event)
 {
 	struct interface *iface;
 	time_t now = odhcpd_time();
@@ -1241,7 +1241,7 @@ static void valid_until_cb(struct uloop_timeout *event)
 int dhcpv4_init(void)
 {
 	static struct netevent_handler dhcpv4_netevent_handler = { .cb = dhcpv4_netevent_cb };
-	static struct uloop_timeout valid_until_timeout = { .cb = valid_until_cb };
+	static struct uloop_timeout valid_until_timeout = { .cb = dhcpv4_valid_until_cb };
 
 	uloop_timeout_set(&valid_until_timeout, 1000);
 	netlink_add_netevent_handler(&dhcpv4_netevent_handler);

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -318,14 +318,6 @@ static int dhcpv4_send_reply(const void *buf, size_t len,
 	return sendto(*sock, buf, len, MSG_DONTWAIT, dest, dest_len);
 }
 
-/* DNR */
-struct dhcpv4_dnr {
-	uint16_t len;
-	uint16_t priority;
-	uint8_t adn_len;
-	uint8_t body[];
-};
-
 void dhcpv4_handle_msg(void *addr, void *data, size_t len,
 		struct interface *iface, _unused void *dest_addr,
 	        send_reply_cb_t send_reply, void *opaque)

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -979,7 +979,7 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg msg, const uint8_t *mac,
 	return a;
 }
 
-static int setup_dhcpv4_addresses(struct interface *iface)
+static int dhcpv4_setup_addresses(struct interface *iface)
 {
 	iface->dhcpv4_start_ip.s_addr = INADDR_ANY;
 	iface->dhcpv4_end_ip.s_addr = INADDR_ANY;
@@ -1133,7 +1133,7 @@ int dhcpv4_setup_interface(struct interface *iface, bool enable)
 			goto out;
 		}
 
-		if (setup_dhcpv4_addresses(iface) < 0) {
+		if (dhcpv4_setup_addresses(iface) < 0) {
 			ret = -1;
 			goto out;
 		}
@@ -1167,7 +1167,7 @@ static void handle_addrlist_change(struct interface *iface)
 	ip.prefix = odhcpd_netmask2bitlen(false, &iface->dhcpv4_mask);
 	ip.broadcast = iface->dhcpv4_bcast;
 
-	setup_dhcpv4_addresses(iface);
+	dhcpv4_setup_addresses(iface);
 
 	if ((ip.addr.in.s_addr & mask) ==
 	    (iface->dhcpv4_local.s_addr & iface->dhcpv4_mask.s_addr))

--- a/src/dhcpv4.h
+++ b/src/dhcpv4.h
@@ -97,6 +97,14 @@ struct dhcpv4_option {
 	uint8_t data[];
 };
 
+/* DNR */
+struct dhcpv4_dnr {
+	uint16_t len;
+	uint16_t priority;
+	uint8_t adn_len;
+	uint8_t body[];
+};
+
 
 #define dhcpv4_for_each_option(start, end, opt)\
 	for (opt = (struct dhcpv4_option*)(start); \


### PR DESCRIPTION
I'm working on cleaning up `dhcpv4.c`. As a first step, I'd like to reorganise the file a bit by moving the functions around. Right now, it's written in a kind of upside-down manner compared to what you'd expect from a C file (i.e. the most generic/init style functions are at the top, and the utility functions are further down, where you'd normally expect it to be the other way around). This currently necessitates a lot of forward declarations.

This might look like a massive change (and the diff looks a bit confusing), but looking at the individual commits, it's mostly just shifting functions around.