### PR TITLE
odhcpd: fix a compilation error

### DIFF
--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -331,7 +331,7 @@ ssize_t odhcpd_try_send_with_src(int socket, struct sockaddr_in6 *dest,
  * - use an IPv6 ULA address if the already selected IPv6 address is not an ULA address
  * - use the IPv6 address with the longest preferred lifetime
  */
-int odhcpd_get_interface_dns_addr(const struct interface *iface, struct in6_addr *addr)
+int odhcpd_get_interface_dns_addr(struct interface *iface, struct in6_addr *addr)
 {
 	time_t now = odhcpd_time();
 	ssize_t m = -1;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -491,7 +491,7 @@ ssize_t odhcpd_send(int socket, struct sockaddr_in6 *dest,
 ssize_t odhcpd_try_send_with_src(int socket, struct sockaddr_in6 *dest,
 		struct iovec *iov, size_t iov_len,
 		struct interface *iface);
-int odhcpd_get_interface_dns_addr(const struct interface *iface,
+int odhcpd_get_interface_dns_addr(struct interface *iface,
 		struct in6_addr *addr);
 int odhcpd_get_interface_linklocal_addr(struct interface *iface,
 		struct in6_addr *addr);


### PR DESCRIPTION
odhcpd_get_interface_dns_addr() calls odhcpd_get_interface_linklocal_addr(), the former takes a const struct interface ptr, the latter takes a non-const struct interface ptr.

The end result is an unhappy compiler.