### PR TITLE
odhcpd: switch to simple log macros, support stderr logging

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -41,6 +41,8 @@ struct config config = {
 	.ra_piofolder_fd = -1,
 	.uci_cfgfile = "dhcp",
 	.log_level = LOG_WARNING,
+	.log_level_cmdline = false,
+	.log_syslog = true,
 };
 
 #define START_DEFAULT	100
@@ -423,9 +425,11 @@ static void set_config(struct uci_section *s)
 	if ((c = tb[ODHCPD_ATTR_LOGLEVEL])) {
 		int log_level = (blobmsg_get_u32(c) & LOG_PRIMASK);
 
-		if (config.log_level != log_level) {
+		if (config.log_level != log_level && config.log_level_cmdline) {
 			config.log_level = log_level;
-			setlogmask(LOG_UPTO(config.log_level));
+			if (config.log_syslog)
+				setlogmask(LOG_UPTO(config.log_level));
+			notice("Log level set to %d\n", config.log_level);
 		}
 	}
 }

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -73,7 +73,7 @@ int dhcpv6_ia_setup_interface(struct interface *iface, bool enable)
 			border = alloc_assignment(0);
 
 			if (!border) {
-				syslog(LOG_WARNING, "Failed to alloc border on %s", iface->name);
+				warn("Failed to alloc border on %s", iface->name);
 				return -1;
 			}
 
@@ -235,9 +235,9 @@ void dhcpv6_ia_enum_addrs(struct interface *iface, struct dhcp_assignment *c,
 		/* Filter Out Prefixes */
 		if (ADDR_MATCH_PIO_FILTER(&addrs[i], iface)) {
 			char addrbuf[INET6_ADDRSTRLEN];
-			syslog(LOG_INFO, "Address %s filtered out on %s",
-				inet_ntop(AF_INET6, &addrs[i].addr.in6, addrbuf, sizeof(addrbuf)),
-				iface->name);
+			info("Address %s filtered out on %s",
+			     inet_ntop(AF_INET6, &addrs[i].addr.in6, addrbuf, sizeof(addrbuf)),
+			     iface->name);
 			continue;
 		}
 
@@ -755,7 +755,7 @@ static bool assign_pd(struct interface *iface, struct dhcp_assignment *assign)
 
 			/* Wait initial period of up to 250ms for immediate assignment */
 			if (poll(&pfd, 1, 250) < 0) {
-				syslog(LOG_ERR, "poll(): %m");
+				error("poll(): %m");
 				return false;
 			}
 
@@ -1074,9 +1074,9 @@ static size_t build_ia(uint8_t *buf, size_t buflen, uint16_t status,
 			/* Filter Out Prefixes */
 			if (ADDR_MATCH_PIO_FILTER(&addrs[i], iface)) {
 				char addrbuf[INET6_ADDRSTRLEN];
-				syslog(LOG_INFO, "Address %s filtered out on %s",
-					inet_ntop(AF_INET6, &addrs[i].addr.in6, addrbuf, sizeof(addrbuf)),
-					iface->name);
+				info("Address %s filtered out on %s",
+				     inet_ntop(AF_INET6, &addrs[i].addr.in6, addrbuf, sizeof(addrbuf)),
+				     iface->name);
 				continue;
 			}
 
@@ -1338,8 +1338,8 @@ static void dhcpv6_log(uint8_t msgtype, struct interface *iface, time_t now,
 		dhcpv6_ia_enum_addrs(iface, a, now, dhcpv6_log_ia_addr, &ctxt);
 	}
 
-	syslog(LOG_INFO, "DHCPV6 %s %s from %s on %s: %s %s", type, (is_pd) ? "IA_PD" : "IA_NA",
-			 duidbuf, iface->name, status, leasebuf);
+	info("DHCPV6 %s %s from %s on %s: %s %s", type, (is_pd) ? "IA_PD" : "IA_NA",
+	     duidbuf, iface->name, status, leasebuf);
 }
 
 static bool dhcpv6_ia_on_link(const struct dhcpv6_ia_hdr *ia, struct dhcp_assignment *a,
@@ -1484,8 +1484,8 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 			 * 1/16 of our total address space.
 			 */
 			if (iface->dhcpv6_pd_min_len && reqlen < iface->dhcpv6_pd_min_len) {
-			    syslog(LOG_INFO, "clamping requested PD from %d to %d",
-				   reqlen, iface->dhcpv6_pd_min_len);
+			    info("clamping requested PD from %d to %d", reqlen,
+				 iface->dhcpv6_pd_min_len);
 			    reqlen = iface->dhcpv6_pd_min_len;
 			}
 		} else if (is_na) {

--- a/src/dhcpv6-pxe.c
+++ b/src/dhcpv6-pxe.c
@@ -63,7 +63,7 @@ void ipv6_pxe_serve_boot_url(uint16_t arch, struct iovec* iov) {
 	else {
 		iov->iov_base = (void*)&(entry->bootfile_url);
 		iov->iov_len = 4 + ntohs(entry->bootfile_url.len);
-		syslog(LOG_INFO, "Serve IPv6 PxE, arch = %d, url = %s", arch, entry->bootfile_url.payload);
+		info("Serve IPv6 PxE, arch = %d, url = %s", arch, entry->bootfile_url.payload);
 	}
 }
 
@@ -79,14 +79,13 @@ void ipv6_pxe_dump(void) {
 	}
 
 	if (count) {
-		syslog(LOG_INFO, "IPv6 PxE URLs:\n");
+		info("IPv6 PxE URLs:\n");
 
-		list_for_each_entry(entry, &ipv6_pxe_list, list) {
-			syslog(LOG_INFO, "    arch %04d = %s\n", entry->arch, entry->bootfile_url.payload);
-		}
+		list_for_each_entry(entry, &ipv6_pxe_list, list)
+			info("    arch %04d = %s\n", entry->arch, entry->bootfile_url.payload);
 
 		if (ipv6_pxe_default)
-			syslog(LOG_INFO, "    Default   = %s\n", ipv6_pxe_default->bootfile_url.payload);
+			info("    Default   = %s\n", ipv6_pxe_default->bootfile_url.payload);
 	}
 }
 

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -67,7 +67,7 @@ int dhcpv6_setup_interface(struct interface *iface, bool enable)
 
 		iface->dhcpv6_event.uloop.fd = socket(AF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
 		if (iface->dhcpv6_event.uloop.fd < 0) {
-			syslog(LOG_ERR, "socket(AF_INET6): %m");
+			error("socket(AF_INET6): %m");
 			ret = -1;
 			goto out;
 		}
@@ -75,28 +75,28 @@ int dhcpv6_setup_interface(struct interface *iface, bool enable)
 		/* Basic IPv6 configuration */
 		if (setsockopt(iface->dhcpv6_event.uloop.fd, SOL_SOCKET, SO_BINDTODEVICE,
 					iface->ifname, strlen(iface->ifname)) < 0) {
-			syslog(LOG_ERR, "setsockopt(SO_BINDTODEVICE): %m");
+			error("setsockopt(SO_BINDTODEVICE): %m");
 			ret = -1;
 			goto out;
 		}
 
 		if (setsockopt(iface->dhcpv6_event.uloop.fd, IPPROTO_IPV6, IPV6_V6ONLY,
 					&val, sizeof(val)) < 0) {
-			syslog(LOG_ERR, "setsockopt(IPV6_V6ONLY): %m");
+			error("setsockopt(IPV6_V6ONLY): %m");
 			ret = -1;
 			goto out;
 		}
 
 		if (setsockopt(iface->dhcpv6_event.uloop.fd, SOL_SOCKET, SO_REUSEADDR,
 					&val, sizeof(val)) < 0) {
-			syslog(LOG_ERR, "setsockopt(SO_REUSEADDR): %m");
+			error("setsockopt(SO_REUSEADDR): %m");
 			ret = -1;
 			goto out;
 		}
 
 		if (setsockopt(iface->dhcpv6_event.uloop.fd, IPPROTO_IPV6, IPV6_RECVPKTINFO,
 					&val, sizeof(val)) < 0) {
-			syslog(LOG_ERR, "setsockopt(IPV6_RECVPKTINFO): %m");
+			error("setsockopt(IPV6_RECVPKTINFO): %m");
 			ret = -1;
 			goto out;
 		}
@@ -104,7 +104,7 @@ int dhcpv6_setup_interface(struct interface *iface, bool enable)
 		val = DHCPV6_HOP_COUNT_LIMIT;
 		if (setsockopt(iface->dhcpv6_event.uloop.fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
 					&val, sizeof(val)) < 0) {
-			syslog(LOG_ERR, "setsockopt(IPV6_MULTICAST_HOPS): %m");
+			error("setsockopt(IPV6_MULTICAST_HOPS): %m");
 			ret = -1;
 			goto out;
 		}
@@ -112,14 +112,14 @@ int dhcpv6_setup_interface(struct interface *iface, bool enable)
 		val = 0;
 		if (setsockopt(iface->dhcpv6_event.uloop.fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP,
 					&val, sizeof(val)) < 0) {
-			syslog(LOG_ERR, "setsockopt(IPV6_MULTICAST_LOOP): %m");
+			error("setsockopt(IPV6_MULTICAST_LOOP): %m");
 			ret = -1;
 			goto out;
 		}
 
 		if (bind(iface->dhcpv6_event.uloop.fd, (struct sockaddr*)&bind_addr,
 					sizeof(bind_addr)) < 0) {
-			syslog(LOG_ERR, "bind(): %m");
+			error("bind(): %m");
 			ret = -1;
 			goto out;
 		}
@@ -130,7 +130,7 @@ int dhcpv6_setup_interface(struct interface *iface, bool enable)
 
 		if (setsockopt(iface->dhcpv6_event.uloop.fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP,
 					&mreq, sizeof(mreq)) < 0) {
-			syslog(LOG_ERR, "setsockopt(IPV6_ADD_MEMBERSHIP): %m");
+			error("setsockopt(IPV6_ADD_MEMBERSHIP): %m");
 			ret = -1;
 			goto out;
 		}
@@ -142,7 +142,7 @@ int dhcpv6_setup_interface(struct interface *iface, bool enable)
 
 			if (setsockopt(iface->dhcpv6_event.uloop.fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP,
 						&mreq, sizeof(mreq)) < 0) {
-				syslog(LOG_ERR, "setsockopt(IPV6_ADD_MEMBERSHIP): %m");
+				error("setsockopt(IPV6_ADD_MEMBERSHIP): %m");
 				ret = -1;
 				goto out;
 			}
@@ -260,7 +260,7 @@ static int send_reply(_unused const void *buf, size_t len,
 	struct dhcpv4_msg_data *reply = opaque;
 
 	if (len > reply->maxsize) {
-		syslog(LOG_ERR, "4o6: reply too large, %zu > %zu", len, reply->maxsize);
+		error("4o6: reply too large, %zu > %zu", len, reply->maxsize);
 		reply->len = -1;
 	} else {
 		memcpy(reply->msg, buf, len);
@@ -290,7 +290,7 @@ static ssize_t dhcpv6_4o6_query(uint8_t *buf, size_t buflen,
 	}
 
 	if (!msgv4_data || msgv4_len == 0) {
-		syslog(LOG_ERR, "4o6: missing DHCPv4 message option (%d)", DHCPV6_OPT_DHCPV4_MSG);
+		error("4o6: missing DHCPv4 message option (%d)", DHCPV6_OPT_DHCPV4_MSG);
 		return -1;
 	}
 
@@ -318,7 +318,7 @@ static void handle_client_request(void *addr, void *data, size_t len,
 	if (len < sizeof(*hdr))
 		return;
 
-	syslog(LOG_DEBUG, "Got a DHCPv6-request on %s", iface->name);
+	debug("Got a DHCPv6-request on %s", iface->name);
 
 	/* Construct reply message */
 	struct __attribute__((packed)) {
@@ -709,7 +709,7 @@ static void handle_client_request(void *addr, void *data, size_t len,
 		msglen = dhcpv6_4o6_query(msg_opt->msg, sizeof(pdbuf) - sizeof(*msg_opt) + 1,
 						iface, addr, (const void *)hdr, opts_end);
 		if (msglen <= 0) {
-			syslog(LOG_ERR, "4o6: query failed");
+			error("4o6: query failed");
 			return;
 		}
 
@@ -741,7 +741,7 @@ static void handle_client_request(void *addr, void *data, size_t len,
 				      iov[IOV_DNR].iov_len + iov[IOV_BOOTFILE_URL].iov_len -
 				      (4 + opts_end - opts));
 
-	syslog(LOG_DEBUG, "Sending a DHCPv6-%s on %s", iov[IOV_NESTED].iov_len ? "relay-reply" : "reply", iface->name);
+	debug("Sending a DHCPv6-%s on %s", iov[IOV_NESTED].iov_len ? "relay-reply" : "reply", iface->name);
 
 	odhcpd_send(iface->dhcpv6_event.uloop.fd, addr, iov, ARRAY_SIZE(iov), iface);
 }
@@ -776,7 +776,7 @@ static void relay_server_response(uint8_t *data, size_t len)
 	/* Relay DHCPv6 reply from server to client */
 	struct dhcpv6_relay_header *h = (void*)data;
 
-	syslog(LOG_DEBUG, "Got a DHCPv6-relay-reply");
+	debug("Got a DHCPv6-relay-reply");
 
 	if (len < sizeof(*h) || h->msg_type != DHCPV6_MSG_RELAY_REPL)
 		return;
@@ -846,7 +846,7 @@ static void relay_server_response(uint8_t *data, size_t len)
 
 	struct iovec iov = {payload_data, payload_len};
 
-	syslog(LOG_DEBUG, "Sending a DHCPv6-reply on %s", iface->name);
+	debug("Sending a DHCPv6-reply on %s", iface->name);
 
 	odhcpd_send(iface->dhcpv6_event.uloop.fd, &target, &iov, 1, iface);
 }
@@ -897,7 +897,7 @@ static void relay_client_request(struct sockaddr_in6 *source,
 	    h->msg_type == DHCPV6_MSG_ADVERTISE)
 		return; /* Invalid message types for client */
 
-	syslog(LOG_DEBUG, "Got a DHCPv6-request on %s", iface->name);
+	debug("Got a DHCPv6-request on %s", iface->name);
 
 	if (h->msg_type == DHCPV6_MSG_RELAY_FORW) { /* handle relay-forward */
 		if (h->hop_count >= DHCPV6_HOP_COUNT_LIMIT)
@@ -938,7 +938,7 @@ static void relay_client_request(struct sockaddr_in6 *source,
 			ip = NULL;
 		}
 
-		syslog(LOG_DEBUG, "Sending a DHCPv6-relay-forward on %s", c->name);
+		debug("Sending a DHCPv6-relay-forward on %s", c->name);
 
 		odhcpd_send(c->dhcpv6_event.uloop.fd, &s, iov, 2, c);
 	}

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -14,7 +14,6 @@
 
 #include <errno.h>
 #include <string.h>
-#include <syslog.h>
 
 #include <linux/netlink.h>
 #include <linux/if_addr.h>
@@ -58,13 +57,13 @@ int netlink_init(void)
 {
 	rtnl_socket = create_socket(NETLINK_ROUTE);
 	if (!rtnl_socket) {
-		syslog(LOG_ERR, "Unable to open nl socket: %m");
+		error("Unable to open nl socket: %m");
 		goto err;
 	}
 
 	rtnl_event.sock = create_socket(NETLINK_ROUTE);
 	if (!rtnl_event.sock) {
-		syslog(LOG_ERR, "Unable to open nl event socket: %m");
+		error("Unable to open nl event socket: %m");
 		goto err;
 	}
 
@@ -352,8 +351,8 @@ static int handle_rtm_addr(struct nlmsghdr *hdr, bool add)
 				return NL_SKIP;
 			}
 
-			syslog(LOG_DEBUG, "Netlink %s %s on %s", add ? "newaddr" : "deladdr",
-					buf, iface->name);
+			debug("Netlink %s %s on %s", add ? "newaddr" : "deladdr",
+			      buf, iface->name);
 
 			event_info.iface = iface;
 			call_netevent_handler_list(add ? NETEV_ADDR6_ADD : NETEV_ADDR6_DEL,
@@ -373,8 +372,8 @@ static int handle_rtm_addr(struct nlmsghdr *hdr, bool add)
 			if (iface->ifindex != (int)ifa->ifa_index)
 				continue;
 
-			syslog(LOG_DEBUG, "Netlink %s %s on %s", add ? "newaddr" : "deladdr",
-					buf, iface->name);
+			debug("Netlink %s %s on %s", add ? "newaddr" : "deladdr",
+			      buf, iface->name);
 
 			event_info.iface = iface;
 			call_netevent_handler_list(add ? NETEV_ADDR_ADD : NETEV_ADDR_DEL,
@@ -417,8 +416,8 @@ static int handle_rtm_neigh(struct nlmsghdr *hdr, bool add)
 		if (iface->ifindex != ndm->ndm_ifindex)
 			continue;
 
-		syslog(LOG_DEBUG, "Netlink %s %s on %s", true ? "newneigh" : "delneigh",
-				buf, iface->name);
+		debug("Netlink %s %s on %s", true ? "newneigh" : "delneigh",
+		      buf, iface->name);
 
 		event_info.iface = iface;
 		event_info.neigh.state = ndm->ndm_state;

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -24,7 +24,6 @@
 #include <unistd.h>
 #include <signal.h>
 #include <stdbool.h>
-#include <syslog.h>
 #include <alloca.h>
 #include <inttypes.h>
 
@@ -115,7 +114,7 @@ int main(int argc, char **argv)
 	uloop_init();
 
 	if (getuid() != 0) {
-		syslog(LOG_ERR, "Must be run as root!");
+		error("Must be run as root!");
 		return 2;
 	}
 
@@ -245,11 +244,11 @@ ssize_t odhcpd_send_with_src(int socket, struct sockaddr_in6 *dest,
 
 	ssize_t sent = sendmsg(socket, &msg, MSG_DONTWAIT);
 	if (sent < 0)
-		syslog(LOG_ERR, "Failed to send to %s%%%s@%s (%m)",
-				ipbuf, iface->name, iface->ifname);
+		error("Failed to send to %s%%%s@%s (%m)",
+		      ipbuf, iface->name, iface->ifname);
 	else
-		syslog(LOG_DEBUG, "Sent %zd bytes to %s%%%s@%s",
-				sent, ipbuf, iface->name, iface->ifname);
+		debug("Sent %zd bytes to %s%%%s@%s",
+		      sent, ipbuf, iface->name, iface->ifname);
 	return sent;
 }
 
@@ -474,8 +473,7 @@ static void odhcpd_receive_packets(struct uloop_fd *u, _unused unsigned int even
 
 		/* From netlink */
 		if (addr.nl.nl_family == AF_NETLINK) {
-			syslog(LOG_DEBUG, "Received %zd Bytes from %s%%netlink", len,
-					ipbuf);
+			debug("Received %zd Bytes from %s%%netlink", len, ipbuf);
 			e->handle_dgram(&addr, data_buf, len, NULL, dest);
 			return;
 		} else if (destiface != 0) {
@@ -485,8 +483,8 @@ static void odhcpd_receive_packets(struct uloop_fd *u, _unused unsigned int even
 				if (iface->ifindex != destiface)
 					continue;
 
-				syslog(LOG_DEBUG, "Received %zd Bytes from %s%%%s@%s", len,
-						ipbuf, iface->name, iface->ifname);
+				debug("Received %zd Bytes from %s%%%s@%s", len,
+				      ipbuf, iface->name, iface->ifname);
 
 				e->handle_dgram(&addr, data_buf, len, iface, dest);
 			}

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -46,6 +46,25 @@
 static int ioctl_sock = -1;
 static int urandom_fd = -1;
 
+void __iflog(int lvl, const char *fmt, ...)
+{
+	va_list ap;
+
+	if (lvl > config.log_level)
+		return;
+
+	va_start(ap, fmt);
+
+	if (config.log_syslog) {
+		vsyslog(lvl, fmt, ap);
+	} else {
+		vfprintf(stderr, fmt, ap);
+		fprintf(stderr, "\n");
+	}
+
+	va_end(ap);
+}
+
 static void sighandler(_unused int signal)
 {
 	uloop_end();

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -69,6 +69,22 @@ struct nl_sock;
 extern struct vlist_tree leases;
 extern struct config config;
 
+#define __iflog(lvl, fmt, ...)						\
+	do {								\
+		if (lvl <= config.log_level)				\
+			syslog(lvl, fmt __VA_OPT__(, ) __VA_ARGS__);	\
+	} while(0)
+
+#define debug(fmt, ...)     __iflog(LOG_DEBUG, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define info(fmt, ...)      __iflog(LOG_INFO, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define notice(fmt, ...)    __iflog(LOG_NOTICE, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define warn(fmt, ...)      __iflog(LOG_WARNING, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define error(fmt, ...)     __iflog(LOG_ERR, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define critical(fmt, ...)  __iflog(LOG_CRIT, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define alert(fmt, ...)     __iflog(LOG_ALERT, fmt __VA_OPT__(, ) __VA_ARGS__)
+#define emergency(fmt, ...) __iflog(LOG_EMERG, fmt __VA_OPT__(, ) __VA_ARGS__)
+
+
 struct odhcpd_event {
 	struct uloop_fd uloop;
 	void (*handle_dgram)(void *addr, void *data, size_t len,

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -69,16 +69,7 @@ struct nl_sock;
 extern struct vlist_tree leases;
 extern struct config config;
 
-#define __iflog(lvl, fmt, ...)							\
-	do {									\
-		if (lvl > config.log_level)					\
-			break;							\
-		if (config.log_syslog)						\
-			syslog(lvl, fmt __VA_OPT__(, ) __VA_ARGS__);		\
-		else								\
-			fprintf(stderr, fmt "\n" __VA_OPT__(, ) __VA_ARGS__);	\
-	} while(0)
-
+void __iflog(int lvl, const char *fmt, ...);
 #define debug(fmt, ...)     __iflog(LOG_DEBUG, fmt __VA_OPT__(, ) __VA_ARGS__)
 #define info(fmt, ...)      __iflog(LOG_INFO, fmt __VA_OPT__(, ) __VA_ARGS__)
 #define notice(fmt, ...)    __iflog(LOG_NOTICE, fmt __VA_OPT__(, ) __VA_ARGS__)

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -69,10 +69,14 @@ struct nl_sock;
 extern struct vlist_tree leases;
 extern struct config config;
 
-#define __iflog(lvl, fmt, ...)						\
-	do {								\
-		if (lvl <= config.log_level)				\
-			syslog(lvl, fmt __VA_OPT__(, ) __VA_ARGS__);	\
+#define __iflog(lvl, fmt, ...)							\
+	do {									\
+		if (lvl > config.log_level)					\
+			break;							\
+		if (config.log_syslog)						\
+			syslog(lvl, fmt __VA_OPT__(, ) __VA_ARGS__);		\
+		else								\
+			fprintf(stderr, fmt "\n" __VA_OPT__(, ) __VA_ARGS__);	\
 	} while(0)
 
 #define debug(fmt, ...)     __iflog(LOG_DEBUG, fmt __VA_OPT__(, ) __VA_ARGS__)
@@ -194,6 +198,8 @@ struct config {
 
 	char *uci_cfgfile;
 	int log_level;
+	bool log_level_cmdline;
+	bool log_syslog;
 };
 
 /* 2-byte type + 128-byte DUID, RFC8415, §11.1 */

--- a/src/router.c
+++ b/src/router.c
@@ -50,13 +50,13 @@ int router_init(void)
 	int ret = 0;
 
 	if (!(fp_route = fopen("/proc/net/ipv6_route", "r"))) {
-		syslog(LOG_ERR, "fopen(/proc/net/ipv6_route): %m");
+		error("fopen(/proc/net/ipv6_route): %m");
 		ret = -1;
 		goto out;
 	}
 
 	if (netlink_add_netevent_handler(&router_netevent_handler) < 0) {
-		syslog(LOG_ERR, "Failed to add netevent handler");
+		error("Failed to add netevent handler");
 		ret = -1;
 	}
 
@@ -103,14 +103,14 @@ int router_setup_interface(struct interface *iface, bool enable)
 			iface->router_event.uloop.fd = socket(AF_INET6, SOCK_RAW | SOCK_CLOEXEC,
 								IPPROTO_ICMPV6);
 			if (iface->router_event.uloop.fd < 0) {
-				syslog(LOG_ERR, "socket(AF_INET6): %m");
+				error("socket(AF_INET6): %m");
 				ret = -1;
 				goto out;
 			}
 
 			if (setsockopt(iface->router_event.uloop.fd, SOL_SOCKET, SO_BINDTODEVICE,
 						iface->ifname, strlen(iface->ifname)) < 0) {
-				syslog(LOG_ERR, "setsockopt(SO_BINDTODEVICE): %m");
+				error("setsockopt(SO_BINDTODEVICE): %m");
 				ret = -1;
 				goto out;
 			}
@@ -118,7 +118,7 @@ int router_setup_interface(struct interface *iface, bool enable)
 			/* Let the kernel compute our checksums */
 			if (setsockopt(iface->router_event.uloop.fd, IPPROTO_RAW, IPV6_CHECKSUM,
 						&val, sizeof(val)) < 0) {
-				syslog(LOG_ERR, "setsockopt(IPV6_CHECKSUM): %m");
+				error("setsockopt(IPV6_CHECKSUM): %m");
 				ret = -1;
 				goto out;
 			}
@@ -127,14 +127,14 @@ int router_setup_interface(struct interface *iface, bool enable)
 			val = 255;
 			if (setsockopt(iface->router_event.uloop.fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
 						&val, sizeof(val)) < 0) {
-				syslog(LOG_ERR, "setsockopt(IPV6_MULTICAST_HOPS): %m");
+				error("setsockopt(IPV6_MULTICAST_HOPS): %m");
 				ret = -1;
 				goto out;
 			}
 
 			if (setsockopt(iface->router_event.uloop.fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS,
 						&val, sizeof(val)) < 0) {
-				syslog(LOG_ERR, "setsockopt(IPV6_UNICAST_HOPS): %m");
+				error("setsockopt(IPV6_UNICAST_HOPS): %m");
 				ret = -1;
 				goto out;
 			}
@@ -143,14 +143,14 @@ int router_setup_interface(struct interface *iface, bool enable)
 			val = 1;
 			if (setsockopt(iface->router_event.uloop.fd, IPPROTO_IPV6, IPV6_RECVPKTINFO,
 						&val, sizeof(val)) < 0) {
-				syslog(LOG_ERR, "setsockopt(IPV6_RECVPKTINFO): %m");
+				error("setsockopt(IPV6_RECVPKTINFO): %m");
 				ret = -1;
 				goto out;
 			}
 
 			if (setsockopt(iface->router_event.uloop.fd, IPPROTO_IPV6, IPV6_RECVHOPLIMIT,
 						&val, sizeof(val)) < 0) {
-				syslog(LOG_ERR, "setsockopt(IPV6_RECVHOPLIMIT): %m");
+				error("setsockopt(IPV6_RECVHOPLIMIT): %m");
 				ret = -1;
 				goto out;
 			}
@@ -159,7 +159,7 @@ int router_setup_interface(struct interface *iface, bool enable)
 			val = 0;
 			if (setsockopt(iface->router_event.uloop.fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP,
 						&val, sizeof(val)) < 0) {
-				syslog(LOG_ERR, "setsockopt(IPV6_MULTICAST_LOOP): %m");
+				error("setsockopt(IPV6_MULTICAST_LOOP): %m");
 				ret = -1;
 				goto out;
 			}
@@ -170,7 +170,7 @@ int router_setup_interface(struct interface *iface, bool enable)
 			ICMP6_FILTER_SETPASS(ND_ROUTER_SOLICIT, &filt);
 			if (setsockopt(iface->router_event.uloop.fd, IPPROTO_ICMPV6, ICMP6_FILTER,
 						&filt, sizeof(filt)) < 0) {
-				syslog(LOG_ERR, "setsockopt(ICMP6_FILTER): %m");
+				error("setsockopt(ICMP6_FILTER): %m");
 				ret = -1;
 				goto out;
 			}
@@ -208,7 +208,7 @@ int router_setup_interface(struct interface *iface, bool enable)
 		if (setsockopt(iface->router_event.uloop.fd, IPPROTO_IPV6,
 					IPV6_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
 			ret = -1;
-			syslog(LOG_ERR, "setsockopt(IPV6_ADD_MEMBERSHIP): %m");
+			error("setsockopt(IPV6_ADD_MEMBERSHIP): %m");
 			goto out;
 		}
 	}
@@ -463,10 +463,10 @@ static void router_add_ra_pio(struct interface *iface,
 			pio->lifetime = 0;
 
 			iface->pio_update = true;
-			syslog(LOG_WARNING, "rfc9096: %s: renew %s/%u",
-				iface->ifname,
-				inet_ntop(AF_INET6, &pio->prefix, ipv6_str, sizeof(ipv6_str)),
-				pio->length);
+			warn("rfc9096: %s: renew %s/%u",
+			     iface->ifname,
+			     inet_ntop(AF_INET6, &pio->prefix, ipv6_str, sizeof(ipv6_str)),
+			     pio->length);
 		}
 
 		return;
@@ -485,10 +485,10 @@ static void router_add_ra_pio(struct interface *iface,
 	pio->lifetime = 0;
 
 	iface->pio_update = true;
-	syslog(LOG_INFO, "rfc9096: %s: add %s/%u",
-		iface->ifname,
-		inet_ntop(AF_INET6, &pio->prefix, ipv6_str, sizeof(ipv6_str)),
-		pio->length);
+	info("rfc9096: %s: add %s/%u",
+	     iface->ifname,
+	     inet_ntop(AF_INET6, &pio->prefix, ipv6_str, sizeof(ipv6_str)),
+	     pio->length);
 }
 
 static void router_clear_ra_pio(time_t now,
@@ -501,11 +501,10 @@ static void router_clear_ra_pio(time_t now,
 		struct ra_pio *cur_pio = &iface->pios[i];
 
 		if (ra_pio_expired(cur_pio, now)) {
-			syslog(LOG_INFO,
-				"rfc9096: %s: clear %s/%u",
-				iface->ifname,
-				inet_ntop(AF_INET6, &cur_pio->prefix, ipv6_str, sizeof(ipv6_str)),
-				cur_pio->length);
+			info("rfc9096: %s: clear %s/%u",
+			     iface->ifname,
+			     inet_ntop(AF_INET6, &cur_pio->prefix, ipv6_str, sizeof(ipv6_str)),
+			     cur_pio->length);
 
 			if (i + 1 < iface->pio_cnt)
 				iface->pios[i] = iface->pios[iface->pio_cnt - 1];
@@ -540,10 +539,10 @@ static void router_stale_ra_pio(struct interface *iface,
 	pio->lifetime = now + iface->max_valid_lifetime;
 
 	iface->pio_update = true;
-	syslog(LOG_WARNING, "rfc9096: %s: stale %s/%u",
-		iface->ifname,
-		inet_ntop(AF_INET6, &pio->prefix, ipv6_str, sizeof(ipv6_str)),
-		pio->length);
+	warn("rfc9096: %s: stale %s/%u",
+	     iface->ifname,
+	     inet_ntop(AF_INET6, &pio->prefix, ipv6_str, sizeof(ipv6_str)),
+	     pio->length);
 }
 
 /* Router Advert server mode */
@@ -670,16 +669,16 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 		uint32_t valid_lt = 0;
 
 		if (addr->prefix > 96 || (i < valid_addr_cnt && addr->valid_lt <= (uint32_t)now)) {
-			syslog(LOG_INFO, "Address %s (prefix %d, valid-lifetime %u) not suitable as RA prefix on %s",
-				inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)), addr->prefix,
-				addr->valid_lt, iface->name);
+			info("Address %s (prefix %d, valid-lifetime %u) not suitable as RA prefix on %s",
+			     inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)), addr->prefix,
+			     addr->valid_lt, iface->name);
 			continue;
 		}
 
 		if (ADDR_MATCH_PIO_FILTER(addr, iface)) {
-			syslog(LOG_INFO, "Address %s filtered out as RA prefix on %s",
-					inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
-					iface->name);
+			info("Address %s filtered out as RA prefix on %s",
+			     inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
+			     iface->name);
 			continue; /* PIO filtered out of this RA */
 		}
 
@@ -695,7 +694,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 
 			tmp = realloc(pfxs, sizeof(*pfxs) * (pfxs_cnt + 1));
 			if (!tmp) {
-				syslog(LOG_ERR, "Realloc failed for RA prefix option on %s", iface->name);
+				error("Realloc failed for RA prefix option on %s", iface->name);
 				continue;
 			}
 
@@ -783,7 +782,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 		highest_found_lifetime = ra_lifetime;
 
 	if (!iface->have_link_local) {
-		syslog(LOG_NOTICE, "Skip sending a RA on %s as no link local address is available", iface->name);
+		notice("Skip sending a RA on %s as no link local address is available", iface->name);
 		goto out;
 	}
 
@@ -792,15 +791,14 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	} else {
 		adv.h.nd_ra_router_lifetime = 0;
 
-		if (default_route) {
-			syslog(LOG_WARNING, "A default route is present but there is no public prefix "
-						"on %s thus we announce no default route by setting ra_lifetime to 0!", iface->name);
-		} else {
-			syslog(LOG_WARNING, "No default route present, setting ra_lifetime to 0!");
-		}
+		if (default_route)
+			warn("A default route is present but there is no public prefix "
+			     "on %s thus we announce no default route by setting ra_lifetime to 0!", iface->name);
+		else
+			warn("No default route present, setting ra_lifetime to 0!");
 	}
 
-	syslog(LOG_DEBUG, "Using a RA lifetime of %d seconds on %s", ntohs(adv.h.nd_ra_router_lifetime), iface->name);
+	debug("Using a RA lifetime of %d seconds on %s", ntohs(adv.h.nd_ra_router_lifetime), iface->name);
 
 	/* DNS options */
 	if (iface->ra_dns) {
@@ -938,17 +936,17 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 		uint32_t valid_lt;
 
 		if (addr->dprefix >= 64 || addr->dprefix == 0 || addr->valid_lt <= (uint32_t)now) {
-			syslog(LOG_INFO, "Address %s (dprefix %d, valid-lifetime %u) not suitable as RA route on %s",
-				inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
-				addr->dprefix, addr->valid_lt, iface->name);
+			info("Address %s (dprefix %d, valid-lifetime %u) not suitable as RA route on %s",
+			     inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
+			     addr->dprefix, addr->valid_lt, iface->name);
 
 			continue; /* Address not suitable */
 		}
 
 		if (ADDR_MATCH_PIO_FILTER(addr, iface)) {
-			syslog(LOG_INFO, "Address %s filtered out as RA route on %s",
-					inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
-					iface->name);
+			info("Address %s filtered out as RA route on %s",
+			     inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
+			     iface->name);
 			continue; /* PIO filtered out of this RA */
 		}
 
@@ -961,7 +959,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 
 		tmp = realloc(routes, sizeof(*routes) * (routes_cnt + 1));
 		if (!tmp) {
-			syslog(LOG_ERR, "Realloc failed for RA route option on %s", iface->name);
+			error("Realloc failed for RA route option on %s", iface->name);
 			continue;
 		}
 
@@ -1008,7 +1006,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	else
 		inet_pton(AF_INET6, ALL_IPV6_NODES, &dest.sin6_addr);
 
-	syslog(LOG_DEBUG, "Sending a RA on %s", iface->name);
+	debug("Sending a RA on %s", iface->name);
 
 	if (odhcpd_send(iface->router_event.uloop.fd, &dest, iov, ARRAY_SIZE(iov), iface) > 0) {
 		iface->ra_sent++;
@@ -1079,7 +1077,7 @@ static void forward_router_solicitation(const struct interface *iface)
 	inet_pton(AF_INET6, ALL_IPV6_ROUTERS, &all_routers.sin6_addr);
 	all_routers.sin6_scope_id = iface->ifindex;
 
-	syslog(LOG_NOTICE, "Sending RS to %s", iface->name);
+	notice("Sending RS to %s", iface->name);
 	odhcpd_send(iface->router_event.uloop.fd, &all_routers, &iov, 1, iface);
 }
 
@@ -1109,7 +1107,7 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 		}
 	}
 
-	syslog(LOG_NOTICE, "Got a RA on %s", iface->name);
+	notice("Got a RA on %s", iface->name);
 
 	/* Indicate a proxy, however we don't follow the rest of RFC 4389 yet */
 	adv->nd_ra_flags_reserved |= ND_RA_FLAG_PROXY;
@@ -1148,7 +1146,7 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 			}
 		}
 
-		syslog(LOG_NOTICE, "Forward a RA on %s", c->name);
+		notice("Forward a RA on %s", c->name);
 
 		odhcpd_send(c->router_event.uloop.fd, &all_nodes, &iov, 1, c);
 	}

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -1,4 +1,3 @@
-#include <syslog.h>
 #include <libubus.h>
 #include <libubox/uloop.h>
 #include <netinet/in.h>
@@ -501,7 +500,7 @@ bool ubus_has_prefix(const char *name, const char *ifname)
 int ubus_init(void)
 {
 	if (!(ubus = ubus_connect(NULL))) {
-		syslog(LOG_ERR, "Unable to connect to ubus: %m");
+		error("Unable to connect to ubus: %m");
 		return -1;
 	}
 


### PR DESCRIPTION
This is mostly for developer ergonomics. My `/var/log/debug` is 150 megs and counting :D

There is one fix wrt. loglevel handling that I'd consider important though. Right now, a loglevel set in the cfg file will override one specified on the command line, which doesn't seem right.

Also, `syslog.h` is already included from `odhcpd.h`, so no need to include it again in a bunch of places.