### PR TITLE
dhcpv6: support a global DUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ and may also receive information from ubus
 | url		|string	| yes	| e.g. `tftp://[fd11::1]/pxe.efi` |
 | arch		|integer| no	| the arch code. `07` is EFI. If not present, this boot6 will be the default. |
 
+odhcpd also uses the UCI configuration file `/etc/config/network` for configuration
+of the following options:
+
+### Section of type globals
+| Option            | Type	|Required|Description |
+| :----------------	| :---- | :----	| :---------- |
+| dhcp_default_duid |string | no	| The DUID to use to identify the DHCPv6 server to clients. |
+
 
 ### System variables for Timezone options (uci system.system)
 | Option  | Type  |Required|Description |

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -191,10 +191,15 @@ static int send_reconf(struct dhcp_assignment *assign)
 		.key = { 0 },
 	};
 
-	uint8_t duid_ll_hdr[] = { 0x00, 0x03, 0x00, 0x01 };
-	memcpy(serverid.data, duid_ll_hdr, sizeof(duid_ll_hdr));
-	odhcpd_get_mac(iface, &serverid.data[sizeof(duid_ll_hdr)]);
-	serverid.len = htons(sizeof(duid_ll_hdr) + ETH_ALEN);
+	if (config.default_duid_len > 0) {
+		memcpy(serverid.data, config.default_duid, config.default_duid_len);
+		serverid.len = htons(config.default_duid_len);
+	} else {
+		uint16_t duid_ll_hdr[] = { htons(DUID_TYPE_LL), htons(ARPHRD_ETHER) };
+		memcpy(serverid.data, duid_ll_hdr, sizeof(duid_ll_hdr));
+		odhcpd_get_mac(iface, &serverid.data[sizeof(duid_ll_hdr)]);
+		serverid.len = htons(sizeof(duid_ll_hdr) + ETH_ALEN);
+	}
 
 	memcpy(clientid.data, assign->clid_data, assign->clid_len);
 

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -378,10 +378,15 @@ static void handle_client_request(void *addr, void *data, size_t len,
 		.serverid_buf = { 0 },
 	};
 
-	uint8_t duid_ll_hdr[] = { 0x00, 0x03, 0x00, 0x01 };
-	memcpy(dest.serverid_buf, duid_ll_hdr, sizeof(duid_ll_hdr));
-	odhcpd_get_mac(iface, &dest.serverid_buf[sizeof(duid_ll_hdr)]);
-	dest.serverid_length = htons(sizeof(duid_ll_hdr) + ETH_ALEN);
+	if (config.default_duid_len > 0) {
+		memcpy(dest.serverid_buf, config.default_duid, config.default_duid_len);
+		dest.serverid_length = htons(config.default_duid_len);
+	} else {
+		uint16_t duid_ll_hdr[] = { htons(DUID_TYPE_LL), htons(ARPHRD_ETHER) };
+		memcpy(dest.serverid_buf, duid_ll_hdr, sizeof(duid_ll_hdr));
+		odhcpd_get_mac(iface, &dest.serverid_buf[sizeof(duid_ll_hdr)]);
+		dest.serverid_length = htons(sizeof(duid_ll_hdr) + ETH_ALEN);
+	}
 
 	struct _packed {
 		uint16_t type;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -183,6 +183,19 @@ enum odhcpd_assignment_flags {
 	OAF_DHCPV6_PD		= (1 << 6),
 };
 
+/* 2-byte type + 128-byte DUID, RFC8415, §11.1 */
+#define DUID_MAX_LEN 130
+/* In theory, 2 (type only), or 7 (DUID-EN + 1-byte data), but be reasonable */
+#define DUID_MIN_LEN 10
+#define DUID_HEXSTRLEN (DUID_MAX_LEN * 2 + 1)
+
+enum duid_type {
+	DUID_TYPE_LLT = 1,
+	DUID_TYPE_EN = 2,
+	DUID_TYPE_LL = 3,
+	DUID_TYPE_UUID = 4,
+};
+
 struct config {
 	bool legacy;
 	bool enable_tz;
@@ -198,6 +211,9 @@ struct config {
 	int log_level;
 	bool log_level_cmdline;
 	bool log_syslog;
+
+	uint8_t default_duid[DUID_MAX_LEN];
+	size_t default_duid_len;
 };
 
 struct sys_conf {
@@ -206,10 +222,6 @@ struct sys_conf {
 	uint8_t *tzdb_tz;
 	size_t tzdb_tz_len;
 };
-
-/* 2-byte type + 128-byte DUID, RFC8415, §11.1 */
-#define DUID_MAX_LEN 130
-#define DUID_HEXSTRLEN (DUID_MAX_LEN * 2 + 1)
 
 struct duid {
 	uint8_t len;


### PR DESCRIPTION
This adds support for a globally defined static DUID.

Currently, odhcpd generates a per-interface DUID-LL, meaning that the DUID is
not stable across interfaces and will change if/when hardware changes.

Supporting a stable DUID brings odhcpd's behaviour in line with [RFC8415, §11](https://datatracker.ietf.org/doc/html/rfc8415#section-11):

```
                                                      ...The DUID is
   designed to be unique across all DHCP clients and servers, and stable
   for any specific client or server.  That is, the DUID used by a
   client or server SHOULD NOT change over time if at all possible; for
   example, a device's DUID should not change as a result of a change in
   the device's network hardware or changes to virtual interfaces...
```
