### PR TITLE
config: remove legacy/maindhcp opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ and may also receive information from ubus
 
 | Option	| Type	|Default| Description |
 | :------------ | :---- | :----	| :---------- |
-| legacy	| bool	| 0	| Enable DHCPv4 if start but no dhcpv4 option set |
-| maindhcp	| bool	| 0	| Use odhcpd as the main DHCPv4 service |
 | leasefile	| string|	| DHCP/v6 lease/hostfile |
 | leasetrigger	| string|	| Lease trigger script |
 | hostsfile	| string|	| DHCP/v6 hostfile |

--- a/src/config.c
+++ b/src/config.c
@@ -32,8 +32,6 @@ static void lease_update(struct vlist_tree *tree, struct vlist_node *node_new,
 struct vlist_tree leases = VLIST_TREE_INIT(leases, lease_cmp, lease_update, true, false);
 AVL_TREE(interfaces, avl_strcmp, false, NULL);
 struct config config = {
-	.legacy = false,
-	.main_dhcpv4 = false,
 	.dhcp_cb = NULL,
 	.dhcp_statefile = NULL,
 	.dhcp_hostsfile = NULL,
@@ -206,8 +204,6 @@ const struct uci_blob_param_list lease_attr_list = {
 };
 
 enum {
-	ODHCPD_ATTR_LEGACY,
-	ODHCPD_ATTR_MAINDHCP,
 	ODHCPD_ATTR_LEASEFILE,
 	ODHCPD_ATTR_LEASETRIGGER,
 	ODHCPD_ATTR_LOGLEVEL,
@@ -217,8 +213,6 @@ enum {
 };
 
 static const struct blobmsg_policy odhcpd_attrs[ODHCPD_ATTR_MAX] = {
-	[ODHCPD_ATTR_LEGACY] = { .name = "legacy", .type = BLOBMSG_TYPE_BOOL },
-	[ODHCPD_ATTR_MAINDHCP] = { .name = "maindhcp", .type = BLOBMSG_TYPE_BOOL },
 	[ODHCPD_ATTR_LEASEFILE] = { .name = "leasefile", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_LEASETRIGGER] = { .name = "leasetrigger", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_LOGLEVEL] = { .name = "loglevel", .type = BLOBMSG_TYPE_INT32 },
@@ -389,12 +383,6 @@ static void set_config(struct uci_section *s)
 	blob_buf_init(&b, 0);
 	uci_to_blob(&b, s, &odhcpd_attr_list);
 	blobmsg_parse(odhcpd_attrs, ODHCPD_ATTR_MAX, tb, blob_data(b.head), blob_len(b.head));
-
-	if ((c = tb[ODHCPD_ATTR_LEGACY]))
-		config.legacy = blobmsg_get_bool(c);
-
-	if ((c = tb[ODHCPD_ATTR_MAINDHCP]))
-		config.main_dhcpv4 = blobmsg_get_bool(c);
 
 	if ((c = tb[ODHCPD_ATTR_LEASEFILE])) {
 		free(config.dhcp_statefile);
@@ -1096,9 +1084,6 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 		iface->dhcpv4_start.s_addr = htonl(blobmsg_get_u32(c));
 		iface->dhcpv4_end.s_addr = htonl(ntohl(iface->dhcpv4_start.s_addr) +
 							LIMIT_DEFAULT - 1);
-
-		if (config.main_dhcpv4 && config.legacy)
-			iface->dhcpv4 = MODE_SERVER;
 	}
 
 	if ((c = tb[IFACE_ATTR_LIMIT]))
@@ -1139,12 +1124,10 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_DHCPV4])) {
 		if ((mode = parse_mode(blobmsg_get_string(c))) >= 0) {
-			if (config.main_dhcpv4) {
-				iface->dhcpv4 = mode;
+			iface->dhcpv4 = mode;
 
-				if (iface->dhcpv4 != MODE_DISABLED)
-					iface->ignore = false;
-			}
+			if (iface->dhcpv4 != MODE_DISABLED)
+				iface->ignore = false;
 		} else
 			syslog(LOG_ERR, "Invalid %s mode configured for interface %s",
 					iface_attrs[IFACE_ATTR_DHCPV4].name, iface->name);

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -167,8 +167,6 @@ enum odhcpd_assignment_flags {
 };
 
 struct config {
-	bool legacy;
-	bool main_dhcpv4;
 	char *dhcp_cb;
 	char *dhcp_statefile;
 	char *dhcp_hostsfile;


### PR DESCRIPTION
If someone wants to use odhcpd as a DHCPv4 server on a standard OpenWrt install they would have to:

a) remove dnsmasq, or disable its DHCPv4 server
b) remove odhcpd-ipv6only
c) install odhcpd
d) uci set dhcp.odhcpd.legacy=1
e) uci set dhcp.odhcpd.maindhcp=1
f) uci set dhcp.lan.start=100 (usually already done)
g) *not* uci set dhcp.lan.dhcpv4=server

The last part is because dhcpv4=server will be automagically set when dhcp.lan.start is set *and* dhcp.odhcpd.legacy and dhcp.odhcpd.maindhcp are set.

This seems a bit superfluous. Installing odhcpd instead of odhcpd-ipv6only and setting dhcp.lan.dhcpv4=server already seems like a pretty clear indication of what the user wants, so remove the extra options and magic dhcpv4=server logic.

(This also needs separate changes to odhcpd.defaults in the main openwrt repo).