### PR TITLE
github: fix CMAKE_SYSTEM_PROCESSOR copy&paste

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: depends/json-c
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DBUILD_SHARED_LIBS=OFF -DDISABLE_EXTRA_LIBS=ON  \
@@ -83,7 +83,7 @@ jobs:
         working-directory: depends/libnl-tiny
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             --install-prefix ${GITHUB_WORKSPACE}/build
@@ -94,7 +94,7 @@ jobs:
         working-directory: depends/libubox
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DBUILD_LUA=OFF -DBUILD_EXAMPLES=OFF \
@@ -106,7 +106,7 @@ jobs:
         working-directory: depends/ubus
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DBUILD_LUA=OFF -DBUILD_EXAMPLES=OFF \
@@ -118,7 +118,7 @@ jobs:
         working-directory: depends/uci
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DBUILD_LUA=OFF \
@@ -129,7 +129,7 @@ jobs:
       - name: Build odhcpd (basic)
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -B build/odhcpd-basic
@@ -138,7 +138,7 @@ jobs:
       - name: Build odhcpd (DHCPv4)
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DDHCPV4_SUPPORT=ON \
@@ -148,7 +148,7 @@ jobs:
       - name: Build odhcpd (UBUS)
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DUBUS=ON \
@@ -158,7 +158,7 @@ jobs:
       - name: Build odhcpd (full)
         run: |
           cmake \
-            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.packages }} \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DDHCPV4_SUPPORT=ON -DUBUS=ON \


### PR DESCRIPTION
CMAKE_SYSTEM_PROCESSOR was incorrectly defined as matrix.packages instead of matrix.arch.

Fixes: 288206c9a2ed ("github: add CI build")