### PR TITLE
odhcdp: use a more suitable clock

### DIFF
--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -551,7 +551,7 @@ int odhcpd_urandom(void *data, size_t len)
 time_t odhcpd_time(void)
 {
 	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
 	return ts.tv_sec;
 }
 


### PR DESCRIPTION
In my testing, CLOCK_MONOTONIC_COARSE uses about 1/3 of the CPU cycles.

And the resolution is completely irrelevant (only the seconds are used).