### PR TITLE
odhcpd: improve odhcpd_urandom()

### DIFF
--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -514,7 +514,7 @@ int odhcpd_get_interface_config(const char *ifname, const char *what);
 int odhcpd_get_mac(const struct interface *iface, uint8_t mac[6]);
 int odhcpd_get_flags(const struct interface *iface);
 struct interface* odhcpd_get_interface_by_index(int ifindex);
-int odhcpd_urandom(void *data, size_t len);
+void odhcpd_urandom(void *data, size_t len);
 
 void odhcpd_run(void);
 time_t odhcpd_time(void);


### PR DESCRIPTION
First, note that not a single caller checks the return value - which is quite reasonable. What are they supposed to do with a failure?

Second, none of the callers do anything that's *really* security-sensitive, the closest we have is the force reconf nonce, and that is blorted out over the network, so it's really a best-effort kind of thing.

Third, odhcpd_urandom() currently doesn't check if it e.g. got interrupted by a signal.

So, simplify and modernize this a bit by using getrandom(), which allows us to skip one fd, and which avoids syscalls by using the vDSO approach instead. Also, check for things like signal interrupts (don't really happen on calls for entropy < 256 bytes, but still). And make a reasonable effort, but not much more.