### PR TITLE
dhcpv4: bump problem scenario up to warn

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -423,7 +423,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcp_assignment *a,
 		}
 	}
 
-	notice("Can't assign any IP address -> address space is full");
+	warn("Can't assign any IP address -> address space is full");
 
 	return false;
 }


### PR DESCRIPTION
This way a potential failure scenario is visible with odhcpds default log level of warn.

Closes #228

@Noltari low effort fix :)