### PR TITLE
odhcpd: fix syslog

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -453,7 +453,7 @@ static void set_config(struct uci_section *s)
 	if ((c = tb[ODHCPD_ATTR_LOGLEVEL])) {
 		int log_level = (blobmsg_get_u32(c) & LOG_PRIMASK);
 
-		if (config.log_level != log_level && config.log_level_cmdline) {
+		if (config.log_level != log_level && !config.log_level_cmdline) {
 			config.log_level = log_level;
 			if (config.log_syslog)
 				setlogmask(LOG_UPTO(config.log_level));


### PR DESCRIPTION
Remove unneeded log_level_cmdline from config, which prevents properly setting the loglevel from the uci config.

This fixes the log issue reported at https://github.com/openwrt/odhcpd/pull/273#issuecomment-3431453342

CC @Alphix @systemcrash 