### PR TITLE
odhcpd: change "-c" cmd line arg to take a dir

### DIFF
--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -194,7 +194,7 @@ struct config {
 	char *ra_piofolder;
 	int ra_piofolder_fd;
 
-	char *uci_cfgfile;
+	char *uci_cfgdir;
 	int log_level;
 	bool log_level_cmdline;
 	bool log_syslog;
@@ -203,7 +203,6 @@ struct config {
 struct sys_conf {
 	uint8_t *posix_tz;
 	size_t posix_tz_len;
-	char *uci_cfgfile;
 	uint8_t *tzdb_tz;
 	size_t tzdb_tz_len;
 };


### PR DESCRIPTION
After the TZ support was added, odhcpd now reads two cfg files potentially. Instead of adding a separate switch for the system UCI file, I've changed the "-c" argument to take a directory. This is more future-proof and also serves as a preparation for the global DUID PR (which will necessitate reading from the UCI "network" file as well).

While I was at it, I also made some tiny improvements to the odhcpd_reload() function to avoid an unnecessary allocation.