### PR TITLE
odhcpd: struct reorganization

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -549,23 +549,20 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg req_msg, const uint8_t *re
 				if (l->hostname)
 					a->hostname = strdup(l->hostname);
 
-				if (l->leasetime)
-					a->leasetime = l->leasetime;
-
 				list_add(&a->lease_list, &l->assignments);
 				a->lease = l;
 			}
 		}
 
 		/* See if we need to clamp the requested leasetime */
-		uint32_t my_leasetime;
-		if (a->leasetime)
-			my_leasetime = a->leasetime;
+		uint32_t max_leasetime;
+		if (a->lease && a->lease->leasetime)
+			max_leasetime = a->lease->leasetime;
 		else
-			my_leasetime = iface->dhcp_leasetime;
+			max_leasetime = iface->dhcp_leasetime;
 
-		if ((*req_leasetime == 0) || (my_leasetime < *req_leasetime))
-			*req_leasetime = my_leasetime;
+		if ((*req_leasetime == 0) || (max_leasetime < *req_leasetime))
+			*req_leasetime = max_leasetime;
 
 		if (req_msg == DHCPV4_MSG_DISCOVER) {
 			a->flags &= ~OAF_BOUND;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -462,13 +462,13 @@ static void dhcpv6_ia_write_hostsfile(time_t now)
 		}
 
 		if (ctxt.iface->dhcpv4 == MODE_SERVER) {
-			struct dhcp_assignment *c;
+			struct dhcpv4_lease *c;
 
-			list_for_each_entry(c, &ctxt.iface->dhcpv4_assignments, head) {
+			list_for_each_entry(c, &ctxt.iface->dhcpv4_leases, head) {
 				if (!(c->flags & OAF_BOUND))
 					continue;
 
-				char ipbuf[INET6_ADDRSTRLEN];
+				char ipbuf[INET_ADDRSTRLEN];
 				struct in_addr addr = {.s_addr = c->addr};
 				inet_ntop(AF_INET, &addr, ipbuf, sizeof(ipbuf) - 1);
 
@@ -585,9 +585,9 @@ void dhcpv6_ia_write_statefile(void)
 			}
 
 			if (ctxt.iface->dhcpv4 == MODE_SERVER) {
-				struct dhcp_assignment *c;
+				struct dhcpv4_lease *c;
 
-				list_for_each_entry(c, &ctxt.iface->dhcpv4_assignments, head) {
+				list_for_each_entry(c, &ctxt.iface->dhcpv4_leases, head) {
 					if (!(c->flags & OAF_BOUND))
 						continue;
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -120,8 +120,9 @@ static int handle_dhcpv6_leases(_unused struct ubus_context *ctx, _unused struct
 		void *i = blobmsg_open_table(&b, iface->ifname);
 		void *j = blobmsg_open_array(&b, "leases");
 
-		struct dhcp_assignment *a, *border = list_last_entry(
-				&iface->ia_assignments, struct dhcp_assignment, head);
+		struct dhcpv6_lease *a, *border;
+
+		border = list_last_entry(&iface->ia_assignments, struct dhcpv6_lease, head);
 
 		list_for_each_entry(a, &iface->ia_assignments, head) {
 			if (a == border || (!INFINITE_VALID(a->valid_until) &&

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -36,8 +36,8 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _unused struct ubus_ob
 		void *i = blobmsg_open_table(&b, iface->ifname);
 		void *j = blobmsg_open_array(&b, "leases");
 
-		struct dhcp_assignment *c;
-		list_for_each_entry(c, &iface->dhcpv4_assignments, head) {
+		struct dhcpv4_lease *c;
+		list_for_each_entry(c, &iface->dhcpv4_leases, head) {
 			if (!INFINITE_VALID(c->valid_until) && c->valid_until < now)
 				continue;
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -225,11 +225,11 @@ static int handle_ra_pio(_unused struct ubus_context *ctx, _unused struct ubus_o
 	return 0;
 }
 
-static int handle_add_lease(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
-		_unused struct ubus_request_data *req, _unused const char *method,
-		struct blob_attr *msg)
+static int handle_add_lease_cfg(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
+				_unused struct ubus_request_data *req, _unused const char *method,
+				struct blob_attr *msg)
 {
-	if (!set_lease_from_blobmsg(msg))
+	if (!config_set_lease_cfg_from_blobmsg(msg))
 		return UBUS_STATUS_OK;
 
 	return UBUS_STATUS_INVALID_ARGUMENT;
@@ -241,7 +241,7 @@ static struct ubus_method main_object_methods[] = {
 #endif /* DHCPV4_SUPPORT */
 	{ .name = "ipv6leases", .handler = handle_dhcpv6_leases },
 	{ .name = "ipv6ra", .handler = handle_ra_pio },
-	UBUS_METHOD("add_lease", handle_add_lease, lease_attrs),
+	UBUS_METHOD("add_lease", handle_add_lease_cfg, lease_cfg_attrs),
 };
 
 static struct ubus_object_type main_object_type =


### PR DESCRIPTION
As promised, I had another big reorg PR in waiting :)

The gist is that `struct lease` is renamed `struct lease_cfg` (since it isn't a *lease*, i.e. the actual "live" contract between server and client, it's the configuration from UCI `host` sections which can be used to provide the cfg for a static lease).

Then `struct dhcp_assignment` is split into two separate structs for dhcpv4 and dhcpv6 leases.