### PR TITLE
odhcpd: document undocumented options, remove deprecated options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${libjson})
 
 
 # Optional Features
-if (${EXT_CER_ID})
-	target_compile_definitions(${PROJECT_NAME} PRIVATE EXT_CER_ID=${EXT_CER_ID})
-endif(${EXT_CER_ID})
-
 if(${UBUS})
 	target_compile_definitions(${PROJECT_NAME} PRIVATE WITH_UBUS)
 	target_sources(${PROJECT_NAME} PRIVATE src/ubus.c)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ and may also receive information from ubus
 | ntp			|list	|`<local address>`| NTP servers to announce accepts IPv4 and IPv6 |
 | ra_management		|string	| -	| TBD |
 | upstream		|list	| -	| TBD |
-| filter_class		|string | -	| TBD |
 | pd_manager		|string | -	| TBD |
 | pd_cer		|string | -	| TBD |
 | ra_advrouter		|bool   | -	| TBD |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ and may also receive information from ubus
 | ndp_from_link_local	|bool	| 1	| Use link-local source addresses for NDP operations (RFC 4861, §4.2 compliance) and macOS compatibility |
 | prefix_filter		|string	|`::/0`	| Only advertise on-link prefixes within the provided IPv6 prefix; others are filtered out. [IPv6 prefix] |
 | ntp			|list	|`<local address>`| NTP servers to announce accepts IPv4 and IPv6 |
+| ra_management		|string	| -	| TBD |
+| upstream		|list	| -	| TBD |
+| filter_class		|string | -	| TBD |
+| pd_manager		|string | -	| TBD |
+| pd_cer		|string | -	| TBD |
+| ra_advrouter		|bool   | -	| TBD |
+
+[//]: # "dhcpv6_raw - string - not documented, may change when generic DHCPv4/DHCPv6 options are added"
 
 
 ### Sections of type host (static leases)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ and may also receive information from ubus
 
 | Option	| Type	|Default| Description |
 | :------------ | :---- | :----	| :---------- |
-| legacy	| bool	| 0	| Enable DHCPv4 if start but no dhcpv4 option set |
 | maindhcp	| bool	| 0	| Use odhcpd as the main DHCPv4 service |
 | leasefile	| string|	| DHCP/v6 lease/hostfile |
 | leasetrigger	| string|	| Lease trigger script |

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ and may also receive information from ubus
 | ndp_from_link_local	|bool	| 1	| Use link-local source addresses for NDP operations (RFC 4861, §4.2 compliance) and macOS compatibility |
 | prefix_filter		|string	|`::/0`	| Only advertise on-link prefixes within the provided IPv6 prefix; others are filtered out. [IPv6 prefix] |
 | ntp			|list	|`<local address>`| NTP servers to announce accepts IPv4 and IPv6 |
-| ra_management		|string	| -	| TBD |
 | upstream		|list	| -	| TBD |
 | ra_advrouter		|bool   | -	| TBD |
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ and may also receive information from ubus
 | ntp			|list	|`<local address>`| NTP servers to announce accepts IPv4 and IPv6 |
 | ra_management		|string	| -	| TBD |
 | upstream		|list	| -	| TBD |
-| pd_manager		|string | -	| TBD |
-| pd_cer		|string | -	| TBD |
 | ra_advrouter		|bool   | -	| TBD |
 
 [//]: # "dhcpv6_raw - string - not documented, may change when generic DHCPv4/DHCPv6 options are added"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ and may also receive information from ubus
 | max_valid_lifetime	|string	| 90m	| Upper limit for the valid lifetime for a prefix |
 | ra_default		|integer| 0	| Override default route - 0: default, 1: ignore no public address, 2: ignore all |
 | ra_flags		|list	|other-config| List of RA flags to be advertised in RA messages [managed-config\|other-config\|home-agent\|none] |
-| ra_slaac		|bool	| 1	| Announce slaac for a prefix |
+| ra_slaac		|bool	| 1	| Advertise that prefixes (which are <= 64 bits long) on this interface can be used for SLAAC (the "A" flag in the PIO, RFC4861, §4.6.2) |
+| ra_advrouter		|bool   | 0	| Advertise the IPv6 address of this router in RA messages (the "R" flag in the PIO, RFC6275, §7.2) |
 | ra_offlink		|bool	| 0	| Announce prefixes off-link |
 | ra_preference		|string	| medium| Route(r) preference [medium\|high\|low] |
 | ra_maxinterval	|integer| 600	| Maximum time allowed between sending unsolicited RA |
@@ -120,7 +121,6 @@ and may also receive information from ubus
 | prefix_filter		|string	|`::/0`	| Only advertise on-link prefixes within the provided IPv6 prefix; others are filtered out. [IPv6 prefix] |
 | ntp			|list	|`<local address>`| NTP servers to announce accepts IPv4 and IPv6 |
 | upstream		|list	| -	| TBD |
-| ra_advrouter		|bool   | -	| TBD |
 
 [//]: # "dhcpv6_raw - string - not documented, may change when generic DHCPv4/DHCPv6 options are added"
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ and may also receive information from ubus
 | ndp_from_link_local	|bool	| 1	| Use link-local source addresses for NDP operations (RFC 4861, §4.2 compliance) and macOS compatibility |
 | prefix_filter		|string	|`::/0`	| Only advertise on-link prefixes within the provided IPv6 prefix; others are filtered out. [IPv6 prefix] |
 | ntp			|list	|`<local address>`| NTP servers to announce accepts IPv4 and IPv6 |
-| upstream		|list	| -	| TBD |
+| upstream		|list	| -	| A list of interfaces which can be used as a source of configuration information (e.g. for NTP servers, if not set explicitly). |
 
 [//]: # "dhcpv6_raw - string - not documented, may change when generic DHCPv4/DHCPv6 options are added"
 

--- a/src/config.c
+++ b/src/config.c
@@ -112,7 +112,6 @@ enum {
 	IFACE_ATTR_DHCPV6_NA,
 	IFACE_ATTR_DHCPV6_HOSTID_LEN,
 	IFACE_ATTR_RA_DEFAULT,
-	IFACE_ATTR_RA_MANAGEMENT,
 	IFACE_ATTR_RA_FLAGS,
 	IFACE_ATTR_RA_SLAAC,
 	IFACE_ATTR_RA_OFFLINK,
@@ -164,7 +163,6 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_DHCPV6_NA] = { .name = "dhcpv6_na", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_DHCPV6_HOSTID_LEN] = { .name = "dhcpv6_hostidlength", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_RA_DEFAULT] = { .name = "ra_default", .type = BLOBMSG_TYPE_INT32 },
-	[IFACE_ATTR_RA_MANAGEMENT] = { .name = "ra_management", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_RA_FLAGS] = { .name = "ra_flags", . type = BLOBMSG_TYPE_ARRAY },
 	[IFACE_ATTR_RA_SLAAC] = { .name = "ra_slaac", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_RA_OFFLINK] = { .name = "ra_offlink", .type = BLOBMSG_TYPE_BOOL },
@@ -1426,27 +1424,6 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_RA_DEFAULT]))
 		iface->default_router = blobmsg_get_u32(c);
-
-	/* IFACE_ATTR_RA_MANAGEMENT aka ra_management is deprecated since 2019 */
-	if (!tb[IFACE_ATTR_RA_FLAGS] && !tb[IFACE_ATTR_RA_SLAAC] &&
-		(c = tb[IFACE_ATTR_RA_MANAGEMENT])) {
-		switch (blobmsg_get_u32(c)) {
-		case 0:
-			iface->ra_flags = ND_RA_FLAG_OTHER;
-			iface->ra_slaac = true;
-			break;
-		case 1:
-			iface->ra_flags = ND_RA_FLAG_OTHER|ND_RA_FLAG_MANAGED;
-			iface->ra_slaac = true;
-			break;
-		case 2:
-			iface->ra_flags = ND_RA_FLAG_OTHER|ND_RA_FLAG_MANAGED;
-			iface->ra_slaac = false;
-			break;
-		default:
-			break;
-		}
-	}
 
 	if ((c = tb[IFACE_ATTR_RA_FLAGS])) {
 		iface->ra_flags = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -194,16 +194,9 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_NTP] = { .name = "ntp", .type = BLOBMSG_TYPE_ARRAY },
 };
 
-static const struct uci_blob_param_info iface_attr_info[IFACE_ATTR_MAX] = {
-	[IFACE_ATTR_UPSTREAM] = { .type = BLOBMSG_TYPE_STRING },
-	[IFACE_ATTR_DNS] = { .type = BLOBMSG_TYPE_STRING },
-	[IFACE_ATTR_DOMAIN] = { .type = BLOBMSG_TYPE_STRING },
-};
-
 const struct uci_blob_param_list interface_attr_list = {
 	.n_params = IFACE_ATTR_MAX,
 	.params = iface_attrs,
-	.info = iface_attr_info,
 };
 
 const struct blobmsg_policy lease_cfg_attrs[LEASE_CFG_ATTR_MAX] = {

--- a/src/config.c
+++ b/src/config.c
@@ -104,7 +104,6 @@ enum {
 	IFACE_ATTR_DNR,
 	IFACE_ATTR_DNS_SERVICE,
 	IFACE_ATTR_DOMAIN,
-	IFACE_ATTR_FILTER_CLASS,
 	IFACE_ATTR_DHCPV4_FORCERECONF,
 	IFACE_ATTR_DHCPV6_RAW,
 	IFACE_ATTR_DHCPV6_ASSIGNALL,
@@ -159,7 +158,6 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_DNR] = { .name = "dnr", .type = BLOBMSG_TYPE_ARRAY },
 	[IFACE_ATTR_DNS_SERVICE] = { .name = "dns_service", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_DOMAIN] = { .name = "domain", .type = BLOBMSG_TYPE_ARRAY },
-	[IFACE_ATTR_FILTER_CLASS] = { .name = "filter_class", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_DHCPV4_FORCERECONF] = { .name = "dhcpv4_forcereconf", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_DHCPV6_RAW] = { .name = "dhcpv6_raw", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_DHCPV6_ASSIGNALL] = { .name ="dhcpv6_assignall", .type = BLOBMSG_TYPE_BOOL },
@@ -348,7 +346,6 @@ static void clean_interface(struct interface *iface)
 	free(iface->dhcpv4_router);
 	free(iface->dhcpv4_dns);
 	free(iface->dhcpv6_raw);
-	free(iface->filter_class);
 	free(iface->dhcpv4_ntp);
 	free(iface->dhcpv6_ntp);
 	free(iface->dhcpv6_sntp);
@@ -1384,11 +1381,6 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			memcpy(&iface->search[iface->search_len], buf, len);
 			iface->search_len += len;
 		}
-	}
-
-	if ((c = tb[IFACE_ATTR_FILTER_CLASS])) {
-		iface->filter_class = realloc(iface->filter_class, blobmsg_data_len(c) + 1);
-		memcpy(iface->filter_class, blobmsg_get_string(c), blobmsg_data_len(c) + 1);
 	}
 
 	if ((c = tb[IFACE_ATTR_DHCPV4_FORCERECONF]))

--- a/src/config.c
+++ b/src/config.c
@@ -127,8 +127,6 @@ enum {
 	IFACE_ATTR_RA_MTU,
 	IFACE_ATTR_RA_DNS,
 	IFACE_ATTR_RA_PREF64,
-	IFACE_ATTR_PD_MANAGER,
-	IFACE_ATTR_PD_CER,
 	IFACE_ATTR_NDPROXY_ROUTING,
 	IFACE_ATTR_NDPROXY_SLAVE,
 	IFACE_ATTR_NDP_FROM_LINK_LOCAL,
@@ -165,8 +163,6 @@ static const struct blobmsg_policy iface_attrs[IFACE_ATTR_MAX] = {
 	[IFACE_ATTR_DHCPV6_PD_MIN_LEN] = { .name = "dhcpv6_pd_min_len", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_DHCPV6_NA] = { .name = "dhcpv6_na", .type = BLOBMSG_TYPE_BOOL },
 	[IFACE_ATTR_DHCPV6_HOSTID_LEN] = { .name = "dhcpv6_hostidlength", .type = BLOBMSG_TYPE_INT32 },
-	[IFACE_ATTR_PD_MANAGER] = { .name = "pd_manager", .type = BLOBMSG_TYPE_STRING },
-	[IFACE_ATTR_PD_CER] = { .name = "pd_cer", .type = BLOBMSG_TYPE_STRING },
 	[IFACE_ATTR_RA_DEFAULT] = { .name = "ra_default", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_RA_MANAGEMENT] = { .name = "ra_management", .type = BLOBMSG_TYPE_INT32 },
 	[IFACE_ATTR_RA_FLAGS] = { .name = "ra_flags", . type = BLOBMSG_TYPE_ARRAY },
@@ -1647,15 +1643,6 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 			error("Invalid %s mode configured for interface '%s'",
 			      iface_attrs[IFACE_ATTR_RA_PREFERENCE].name, iface->name);
 	}
-
-	if ((c = tb[IFACE_ATTR_PD_MANAGER]))
-		strncpy(iface->dhcpv6_pd_manager, blobmsg_get_string(c),
-				sizeof(iface->dhcpv6_pd_manager) - 1);
-
-	if ((c = tb[IFACE_ATTR_PD_CER]) &&
-			inet_pton(AF_INET6, blobmsg_get_string(c), &iface->dhcpv6_pd_cer) < 1)
-		error("Invalid %s value configured for interface '%s'",
-		      iface_attrs[IFACE_ATTR_PD_CER].name, iface->name);
 
 	if ((c = tb[IFACE_ATTR_NDPROXY_ROUTING]))
 		iface->learn_routes = blobmsg_get_bool(c);

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -927,16 +927,6 @@ void dhcpv4_handle_msg(void *src_addr, void *data, size_t len,
 				req_opts_len = opt->len;
 			}
 			break;
-		case DHCPV4_OPT_USER_CLASS:
-			if (iface->filter_class) {
-				uint8_t *c = opt->data, *cend = &opt->data[opt->len];
-				for (; c < cend && &c[*c] < cend; c = &c[1 + *c]) {
-					size_t elen = strlen(iface->filter_class);
-					if (*c == elen && !memcmp(&c[1], iface->filter_class, elen))
-						return; // Ignore from homenet
-				}
-			}
-			break;
 		case DHCPV4_OPT_LEASETIME:
 			if (opt->len == 4) {
 				memcpy(&req_leasetime, opt->data, 4);

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -680,13 +680,6 @@ static void handle_client_request(void *addr, void *data, size_t len,
 			if (olen != ntohs(dest.serverid_length) ||
 			    memcmp(odata, &dest.serverid_buf, olen))
 				return; /* Not for us */
-		} else if (iface->filter_class && otype == DHCPV6_OPT_USER_CLASS) {
-			uint8_t *c = odata, *cend = &odata[olen];
-			for (; &c[2] <= cend && &c[2 + (c[0] << 8) + c[1]] <= cend; c = &c[2 + (c[0] << 8) + c[1]]) {
-				size_t elen = strlen(iface->filter_class);
-				if (((((size_t)c[0]) << 8) | c[1]) == elen && !memcmp(&c[2], iface->filter_class, elen))
-					return; /* Ignore from homenet */
-			}
 		} else if (otype == DHCPV6_OPT_IA_PD) {
 #ifdef EXT_CER_ID
 			iov[IOV_CERID].iov_len = sizeof(cerid);

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -84,11 +84,6 @@ static void print_usage(const char *app)
 #else
 	       " no-ubus"
 #endif /* WITH_UBUS */
-#ifdef EXT_CER_ID
-	       " cer"
-#else
-	       " no-cer"
-#endif /* EXT_CER_ID */
 	       "\n"
 	       "\n"
 	       "	-c <dir>	Read UCI configuration files from <dir>\n"

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -450,8 +450,6 @@ struct interface {
 	char *upstream;
 	size_t upstream_len;
 
-	char *filter_class;
-
 	// NTP
 	struct in_addr *dhcpv4_ntp;
 	size_t dhcpv4_ntp_cnt;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -275,10 +275,6 @@ struct dhcpv6_lease {
 	uint32_t iaid;
 	uint8_t length; // length == 128 -> IA_NA, length <= 64 -> IA_PD
 
-	struct odhcpd_ipaddr *managed;
-	ssize_t managed_size;
-	struct ustream_fd managed_sock;
-
 	unsigned int flags;
 	uint32_t leasetime;
 	char *hostname;
@@ -365,10 +361,6 @@ struct interface {
 	struct odhcpd_event dhcpv4_event;
 	struct list_head dhcpv4_leases;
 	struct list_head dhcpv4_fr_ips;
-
-	// Managed PD
-	char dhcpv6_pd_manager[128];
-	struct in6_addr dhcpv6_pd_cer;
 
 	// Services
 	enum odhcpd_mode ra;

--- a/src/router.c
+++ b/src/router.c
@@ -743,6 +743,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 		if (iface->ra_slaac && addr->prefix <= 64)
 			p->nd_opt_pi_flags_reserved |= ND_OPT_PI_FLAG_AUTO;
 		if (iface->ra_advrouter)
+			// RFC6275, §7.2
 			p->nd_opt_pi_flags_reserved |= ND_OPT_PI_FLAG_RADDR;
 		if (i >= valid_addr_cnt || !preferred_lt) {
 			/* 


### PR DESCRIPTION
I've gone through `src/config.c` and reviewed the options defined there, comparing them to what's currently in `README.md`. There are a couple of options that are currently undocumented.

Going through them, I found a number of options that are no longer necessary, so this PR removes a bunch of options for a nice cleanup (especially happy about the `CER`/`pd_managed` removal, which makes the code in `src/dhcpv6-ia.c` much easier to follow).