### PR TITLE
router: Rewrite the ingress MTU to one configured for the interface

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -257,6 +257,13 @@ static int handle_rtm_link(struct nlmsghdr *hdr)
 
 		iface->ifflags = ifi->ifi_flags;
 
+		/* store current MTU if available */
+		if (nla[IFLA_MTU]) {
+			iface->if_mtu = nla_get_u32(nla[IFLA_MTU]);
+			debug("Netlink setting interface '%s' if_mtu MTU to %d",
+					iface->name, iface->if_mtu);
+		}
+
 		/*
 		 * Assume for link event of the same index, that link changed
 		 * and reload services to enable or disable them based on the

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -333,6 +333,7 @@ struct interface {
 	int ifindex;
 	char *ifname;
 	const char *name;
+	uint32_t if_mtu;
 
 	// IPv6 runtime data
 	struct odhcpd_ipaddr *addr6;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -406,7 +406,7 @@ struct interface {
 	uint32_t ra_reachabletime;
 	uint32_t ra_retranstime;
 	uint32_t ra_hoplimit;
-	int ra_mtu;
+	uint32_t ra_mtu;
 	uint32_t max_preferred_lifetime;
 	uint32_t max_valid_lifetime;
 

--- a/src/router.c
+++ b/src/router.c
@@ -569,7 +569,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	 * for shortest lived prefix
 	 */
 	uint32_t lowest_found_lifetime = UINT32_MAX, highest_found_lifetime = 0, maxival, ra_lifetime;
-	int msecs, mtu = iface->ra_mtu, hlim = iface->ra_hoplimit;
+	int msecs, hlim = iface->ra_hoplimit;
 	bool default_route = false;
 	bool valid_prefix = false;
 	char buf[INET6_ADDRSTRLEN];
@@ -602,13 +602,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	adv.mtu.nd_opt_mtu_type = ND_OPT_MTU;
 	adv.mtu.nd_opt_mtu_len = 1;
 
-	if (mtu == 0)
-		mtu = odhcpd_get_interface_config(iface->ifname, "mtu");
-
-	if (mtu < 1280)
-		mtu = 1280;
-
-	adv.mtu.nd_opt_mtu_mtu = htonl(mtu);
+	adv.mtu.nd_opt_mtu_mtu = htonl(iface->ra_mtu);
 
 	iov[IOV_RA_ADV].iov_base = (char *)&adv;
 	iov[IOV_RA_ADV].iov_len = sizeof(adv);


### PR DESCRIPTION
There are edge cases where routers forward ICMPv6 RA which contain an MTU which is too large/small for the receiving client. Override the ingress MTU with the value configured on the interface.

ping @KA2107

Take this for a spin to see whether it fixes your problem.