### PR TITLE
dhcpv4: lazy store statefiles

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -344,6 +344,7 @@ static void set_interface_defaults(struct interface *iface)
 	iface->ra_lifetime = 3 * iface->ra_maxinterval; /* RFC4861: AdvDefaultLifetime: Default: 3 * MaxRtrAdvInterval */
 	iface->ra_dns = true;
 	iface->pio_update = false;
+	iface->update_statefile = true;
 }
 
 static void clean_interface(struct interface *iface)

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -338,6 +338,7 @@ struct interface {
 	char *ifname;
 	const char *name;
 	uint32_t if_mtu;
+	bool update_statefile;
 
 	// IPv6 runtime data
 	struct odhcpd_ipaddr *addr6;


### PR DESCRIPTION
Right now, dhcpv4 saves the statefile on every change and also calls the leasetrigger script on every change (which triggers a dnsmasq reload).

With this change, the statefile is written every N seconds, assuming that there are any changes.

Before this change (without leasetrigger):

```shell
$ time sudo ./build/dhcpdig -4 benchmark foo-client

Thread[**]: req 10000101/0 rel 10000101/0 rep 10000101/0

real	55m29.406s
user	0m0.005s
sys	0m0.010s
```

(This is a simple benchmark tool I wrote, it runs 10 threads which divide the DHVPv4 pool into 10 chunks and then performs 1 million random addr req/release per thread in a loop).

After this change:
```shell
$ time sudo ./build/dhcpdig -4 benchmark foo-client

Thread[**]: req 10000101/0 rel 10000101/0 rep 10000101/0

real	1m48.123s
user	0m0.005s
sys	0m0.005s
```

A 3082% speedup.