### PR TITLE
odhcpd: statefile and hostsfile improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	src/dhcpv6-pxe.c
 	src/ndp.c
 	src/netlink.c
+	src/statefiles.c
 	src/router.c
 )
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ prefix delegation and can be used to relay RA, DHCPv6 and NDP between routed
      * stateless and stateful address assignment
      * prefix delegation support
      * dynamic reconfiguration in case prefixes change
-     * hostname detection and hosts-file creation
+     * hostname detection and hosts-files creation
 
    * relay: mostly standards-compliant DHCPv6-relay
      * support for rewriting announced DNS-server addresses
@@ -64,7 +64,7 @@ and may also receive information from ubus
 | maindhcp	| bool	| 0	| Use odhcpd as the main DHCPv4 service |
 | leasefile	| string|	| DHCP/v6 lease/hostfile |
 | leasetrigger	| string|	| Lease trigger script |
-| hostsfile	| string|	| DHCP/v6 hostfile |
+| hostsdir	| string|	| DHCP/v6 hostfile directory (one file per interface will be created) |
 | loglevel	|integer| 6	| Syslog level priority (0-7) |
 | piofolder	|string |	| Folder to store IPv6 prefix information (to detect stale prefixes, see RFC9096, §3.5) |
 | enable_tz |bool | 1 | Toggle whether RFC4833 timezone information is sent to clients, if set in system  |

--- a/src/config.c
+++ b/src/config.c
@@ -39,6 +39,7 @@ struct config config = {
 	.main_dhcpv4 = false,
 	.dhcp_cb = NULL,
 	.dhcp_statefile = NULL,
+	.dhcp_statedir_fd = -1,
 	.dhcp_hostsfile = NULL,
 	.dhcp_hostsdir_fd = -1,
 	.ra_piofolder = NULL,
@@ -2308,9 +2309,16 @@ void odhcpd_reload(void)
 	uci_unload(uci, system);
 
 	if (config.dhcp_statefile) {
-		char *path = strdupa(config.dhcp_statefile);
+		char *dir = dirname(strdupa(config.dhcp_statefile));
+		char *file = basename(config.dhcp_statefile);
 
-		mkdir_p(dirname(path), 0755);
+		memmove(config.dhcp_statefile, file, strlen(file) + 1);
+		mkdir_p(dir, 0755);
+
+		close(config.dhcp_statedir_fd);
+		config.dhcp_statedir_fd = open(dir, O_PATH | O_DIRECTORY | O_CLOEXEC);
+		if (config.dhcp_statedir_fd < 0)
+			error("Unable to open statedir: '%s': %m", dir);
 	}
 
 	if (config.dhcp_hostsfile) {

--- a/src/config.c
+++ b/src/config.c
@@ -40,7 +40,7 @@ struct config config = {
 	.dhcp_cb = NULL,
 	.dhcp_statefile = NULL,
 	.dhcp_statedir_fd = -1,
-	.dhcp_hostsfile = NULL,
+	.dhcp_hostsdir = NULL,
 	.dhcp_hostsdir_fd = -1,
 	.ra_piofolder = NULL,
 	.ra_piofolder_fd = -1,
@@ -213,7 +213,7 @@ enum {
 	ODHCPD_ATTR_LEASEFILE,
 	ODHCPD_ATTR_LEASETRIGGER,
 	ODHCPD_ATTR_LOGLEVEL,
-	ODHCPD_ATTR_HOSTSFILE,
+	ODHCPD_ATTR_HOSTSDIR,
 	ODHCPD_ATTR_PIOFOLDER,
 	ODHCPD_ATTR_ENABLE_TZ,
 	ODHCPD_ATTR_MAX
@@ -224,7 +224,7 @@ static const struct blobmsg_policy odhcpd_attrs[ODHCPD_ATTR_MAX] = {
 	[ODHCPD_ATTR_LEASEFILE] = { .name = "leasefile", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_LEASETRIGGER] = { .name = "leasetrigger", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_LOGLEVEL] = { .name = "loglevel", .type = BLOBMSG_TYPE_INT32 },
-	[ODHCPD_ATTR_HOSTSFILE] = { .name = "hostsfile", .type = BLOBMSG_TYPE_STRING },
+	[ODHCPD_ATTR_HOSTSDIR] = { .name = "hostsdir", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_PIOFOLDER] = { .name = "piofolder", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_ENABLE_TZ] = { .name = "enable_tz", .type = BLOBMSG_TYPE_BOOL },
 };
@@ -456,9 +456,9 @@ static void set_config(struct uci_section *s)
 		config.dhcp_statefile = strdup(blobmsg_get_string(c));
 	}
 
-	if ((c = tb[ODHCPD_ATTR_HOSTSFILE])) {
-		free(config.dhcp_hostsfile);
-		config.dhcp_hostsfile = strdup(blobmsg_get_string(c));
+	if ((c = tb[ODHCPD_ATTR_HOSTSDIR])) {
+		free(config.dhcp_hostsdir);
+		config.dhcp_hostsdir = strdup(blobmsg_get_string(c));
 	}
 
 	if ((c = tb[ODHCPD_ATTR_PIOFOLDER])) {
@@ -2321,11 +2321,9 @@ void odhcpd_reload(void)
 			error("Unable to open statedir: '%s': %m", dir);
 	}
 
-	if (config.dhcp_hostsfile) {
-		char *dir = dirname(strdupa(config.dhcp_hostsfile));
-		char *file = basename(config.dhcp_hostsfile);
+	if (config.dhcp_hostsdir) {
+		char *dir = strdupa(config.dhcp_hostsdir);
 
-		memmove(config.dhcp_hostsfile, file, strlen(file) + 1);
 		mkdir_p(dir, 0755);
 
 		close(config.dhcp_hostsdir_fd);

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -35,6 +35,7 @@
 #include "odhcpd.h"
 #include "dhcpv4.h"
 #include "dhcpv6.h"
+#include "statefiles.h"
 
 #define MAX_PREFIX_LEN 28
 

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1597,7 +1597,7 @@ static void dhcpv4_valid_until_cb(struct uloop_timeout *event)
 	}
 
 	if (update_statefile)
-		dhcpv6_ia_write_statefile();
+		statefiles_write();
 
 	uloop_timeout_set(event, 5000);
 }

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -818,8 +818,8 @@ struct log_ctxt {
 	int buf_idx;
 };
 
-static void dhcpv6_log_ia_addr(struct in6_addr *addr, int prefix, _unused uint32_t pref_lt,
-				_unused uint32_t valid_lt, void *arg)
+static void dhcpv6_log_ia_addr(_unused struct dhcpv6_lease *lease, struct in6_addr *addr, int prefix,
+			       _unused uint32_t pref_lt, _unused uint32_t valid_lt, void *arg)
 {
 	struct log_ctxt *ctxt = (struct log_ctxt *)arg;
 	char addrbuf[INET6_ADDRSTRLEN];

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -884,7 +884,7 @@ static void dhcpv6_log(uint8_t msgtype, struct interface *iface, time_t now,
 					.buf_len = sizeof(leasebuf),
 					.buf_idx = 0 };
 
-		dhcpv6_ia_enum_addrs(iface, a, now, dhcpv6_log_ia_addr, &ctxt);
+		odhcpd_enum_addr6(iface, a, now, dhcpv6_log_ia_addr, &ctxt);
 	}
 
 	info("DHCPV6 %s %s from %s on %s: %s %s", type, (is_pd) ? "IA_PD" : "IA_NA",

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -502,7 +502,7 @@ static void handle_addrlist_change(struct netevent_handler_info *info)
 			dhcpv6_free_lease(c);
 	}
 
-	dhcpv6_ia_write_statefile();
+	statefiles_write();
 }
 
 static void reconf_timeout_cb(struct uloop_timeout *event)
@@ -1313,7 +1313,7 @@ proceed:
 		break;
 	}
 
-	dhcpv6_ia_write_statefile();
+	statefiles_write();
 
 out:
 	return response_len;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -16,27 +16,20 @@
 #include "odhcpd.h"
 #include "dhcpv6.h"
 #include "dhcpv4.h"
+#include "dhcpv6-ia.h"
+#include "statefiles.h"
 
 #include <time.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <poll.h>
-#include <alloca.h>
 #include <resolv.h>
-#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <libgen.h>
 #include <stdbool.h>
 #include <arpa/inet.h>
 
 #include <libubox/md5.h>
-
-#define ADDR_ENTRY_VALID_IA_ADDR(iface, i, m, addrs) \
-    ((iface)->dhcpv6_assignall || (i) == (m) || \
-     (addrs)[(i)].prefix > 64)
 
 static void dhcpv6_netevent_cb(unsigned long event, struct netevent_handler_info *info);
 static void apply_lease(struct dhcpv6_lease *a, bool add);
@@ -49,7 +42,6 @@ static void valid_until_cb(struct uloop_timeout *event);
 static struct netevent_handler dhcpv6_netevent_handler = { .cb = dhcpv6_netevent_cb, };
 static struct uloop_timeout valid_until_timeout = {.cb = valid_until_cb};
 static uint32_t serial = 0;
-static uint8_t statemd5[16];
 
 static struct dhcpv6_lease *
 dhcpv6_alloc_lease(size_t extra_len)
@@ -139,18 +131,7 @@ static void dhcpv6_netevent_cb(unsigned long event, struct netevent_handler_info
 	}
 }
 
-
-static inline bool valid_prefix_length(const struct dhcpv6_lease *a, const uint8_t prefix_length)
-{
-	return a->length > prefix_length;
-}
-
-static inline bool valid_addr(const struct odhcpd_ipaddr *addr, time_t now)
-{
-	return (addr->prefix <= 96 && addr->valid_lt > (uint32_t)now && addr->preferred_lt > (uint32_t)now);
-}
-
-static size_t get_preferred_addr(const struct odhcpd_ipaddr *addrs, const size_t addrlen)
+size_t get_preferred_addr(const struct odhcpd_ipaddr *addrs, const size_t addrlen)
 {
 	size_t i, m;
 
@@ -286,7 +267,7 @@ static void in6_copy_iid(struct in6_addr *dest, uint64_t iid, unsigned n)
 	}
 }
 
-static struct in6_addr in6_from_prefix_and_iid(const struct odhcpd_ipaddr *prefix, uint64_t iid)
+struct in6_addr in6_from_prefix_and_iid(const struct odhcpd_ipaddr *prefix, uint64_t iid)
 {
 	struct in6_addr addr;
 	uint8_t iid_len = min(128 - prefix->prefix, 64);
@@ -295,374 +276,6 @@ static struct in6_addr in6_from_prefix_and_iid(const struct odhcpd_ipaddr *prefi
 	in6_copy_iid(&addr, iid, iid_len);
 
 	return addr;
-}
-
-void dhcpv6_ia_enum_addrs(struct interface *iface, struct dhcpv6_lease *c,
-			  time_t now, dhcpv6_binding_cb_handler_t func, void *arg)
-{
-	struct odhcpd_ipaddr *addrs = iface->addr6;
-	size_t m = get_preferred_addr(addrs, iface->addr6_len);
-
-	for (size_t i = 0; i < iface->addr6_len; ++i) {
-		struct in6_addr addr;
-		uint32_t preferred_lt, valid_lt;
-		int prefix = c->length;
-
-		if (!valid_addr(&addrs[i], now))
-			continue;
-
-		/* Filter Out Prefixes */
-		if (ADDR_MATCH_PIO_FILTER(&addrs[i], iface)) {
-			char addrbuf[INET6_ADDRSTRLEN];
-			info("Address %s filtered out on %s",
-			     inet_ntop(AF_INET6, &addrs[i].addr.in6, addrbuf, sizeof(addrbuf)),
-			     iface->name);
-			continue;
-		}
-
-		if (c->flags & OAF_DHCPV6_NA) {
-			if (!ADDR_ENTRY_VALID_IA_ADDR(iface, i, m, addrs))
-				continue;
-
-			addr = in6_from_prefix_and_iid(&addrs[i], c->assigned_host_id);
-		} else {
-			if (!valid_prefix_length(c, addrs[i].prefix))
-				continue;
-
-			addr = addrs[i].addr.in6;
-			addr.s6_addr32[1] |= htonl(c->assigned_subnet_id);
-			addr.s6_addr32[2] = addr.s6_addr32[3] = 0;
-		}
-
-		preferred_lt = addrs[i].preferred_lt;
-		if (preferred_lt > (uint32_t)c->preferred_until)
-			preferred_lt = c->preferred_until;
-
-		if (preferred_lt > (uint32_t)c->valid_until)
-			preferred_lt = c->valid_until;
-
-		if (preferred_lt != UINT32_MAX)
-			preferred_lt -= now;
-
-		valid_lt = addrs[i].valid_lt;
-		if (valid_lt > (uint32_t)c->valid_until)
-			valid_lt = c->valid_until;
-
-		if (valid_lt != UINT32_MAX)
-			valid_lt -= now;
-
-		func(&addr, prefix, preferred_lt, valid_lt, arg);
-	}
-}
-
-struct write_ctxt {
-	FILE *fp;
-	md5_ctx_t md5;
-	struct dhcpv6_lease *c;
-	struct interface *iface;
-	char *buf;
-	int buf_len;
-	int buf_idx;
-};
-
-static void dhcpv6_write_ia_addrhosts(struct in6_addr *addr, int prefix, _unused uint32_t pref_lt,
-				_unused uint32_t valid_lt, void *arg)
-{
-	struct write_ctxt *ctxt = (struct write_ctxt *)arg;
-	char ipbuf[INET6_ADDRSTRLEN];
-
-	if ((ctxt->c->flags & OAF_DHCPV6_NA) && ctxt->c->hostname &&
-	    !(ctxt->c->flags & OAF_BROKEN_HOSTNAME)) {
-		inet_ntop(AF_INET6, addr, ipbuf, sizeof(ipbuf) - 1);
-		fputs(ipbuf, ctxt->fp);
-
-		char b[256];
-		if (dn_expand(ctxt->iface->search, ctxt->iface->search + ctxt->iface->search_len,
-				ctxt->iface->search, b, sizeof(b)) > 0)
-			fprintf(ctxt->fp, "\t%s.%s", ctxt->c->hostname, b);
-
-		fprintf(ctxt->fp, "\t%s\n", ctxt->c->hostname);
-	}
-}
-
-static void dhcpv6_write_ia_addr(struct in6_addr *addr, int prefix, _unused uint32_t pref_lt,
-				_unused uint32_t valid_lt, void *arg)
-{
-	struct write_ctxt *ctxt = (struct write_ctxt *)arg;
-	char ipbuf[INET6_ADDRSTRLEN];
-
-	inet_ntop(AF_INET6, addr, ipbuf, sizeof(ipbuf) - 1);
-
-	if ((ctxt->c->flags & OAF_DHCPV6_NA) && ctxt->c->hostname &&
-	    !(ctxt->c->flags & OAF_BROKEN_HOSTNAME)) {
-		fputs(ipbuf, ctxt->fp);
-
-		char b[256];
-		if (dn_expand(ctxt->iface->search, ctxt->iface->search + ctxt->iface->search_len,
-				ctxt->iface->search, b, sizeof(b)) > 0)
-			fprintf(ctxt->fp, "\t%s.%s", ctxt->c->hostname, b);
-
-		fprintf(ctxt->fp, "\t%s\n", ctxt->c->hostname);
-		md5_hash(ipbuf, strlen(ipbuf), &ctxt->md5);
-		md5_hash(ctxt->c->hostname, strlen(ctxt->c->hostname), &ctxt->md5);
-	}
-
-	ctxt->buf_idx += snprintf(ctxt->buf + ctxt->buf_idx,ctxt->buf_len - ctxt->buf_idx,
-					"%s/%d ", ipbuf, prefix);
-}
-
-static void dhcpv6_ia_write_hostsfile(time_t now)
-{
-	struct write_ctxt ctxt;
-
-	unsigned hostsfile_strlen = strlen(config.dhcp_hostsfile) + 1;
-	unsigned tmp_hostsfile_strlen = hostsfile_strlen + 1; /* space for . */
-	char *tmp_hostsfile = alloca(tmp_hostsfile_strlen);
-
-	char *dir_hostsfile;
-	char *base_hostsfile;
-	char *pdir_hostsfile;
-	char *pbase_hostsfile;
-
-	int fd, ret;
-
-	dir_hostsfile = strndup(config.dhcp_hostsfile, hostsfile_strlen);
-	base_hostsfile = strndup(config.dhcp_hostsfile, hostsfile_strlen);
-
-	pdir_hostsfile = dirname(dir_hostsfile);
-	pbase_hostsfile = basename(base_hostsfile);
-
-	snprintf(tmp_hostsfile, tmp_hostsfile_strlen, "%s/.%s", pdir_hostsfile, pbase_hostsfile);
-
-	free(dir_hostsfile);
-	free(base_hostsfile);
-
-	fd = open(tmp_hostsfile, O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
-	if (fd < 0)
-		return;
-
-	ret = lockf(fd, F_LOCK, 0);
-	if (ret < 0) {
-		close(fd);
-		return;
-	}
-
-	if (ftruncate(fd, 0) < 0) {}
-
-	ctxt.fp = fdopen(fd, "w");
-	if (!ctxt.fp) {
-		close(fd);
-		return;
-	}
-
-	avl_for_each_element(&interfaces, ctxt.iface, avl) {
-		if (ctxt.iface->dhcpv6 != MODE_SERVER &&
-				ctxt.iface->dhcpv4 != MODE_SERVER)
-			continue;
-
-		if (ctxt.iface->dhcpv6 == MODE_SERVER) {
-			list_for_each_entry(ctxt.c, &ctxt.iface->ia_assignments, head) {
-				if (!(ctxt.c->flags & OAF_BOUND))
-					continue;
-
-				if (INFINITE_VALID(ctxt.c->valid_until) || ctxt.c->valid_until > now)
-					dhcpv6_ia_enum_addrs(ctxt.iface, ctxt.c, now,
-							     dhcpv6_write_ia_addrhosts, &ctxt);
-			}
-		}
-
-		if (ctxt.iface->dhcpv4 == MODE_SERVER) {
-			struct dhcpv4_lease *c;
-
-			list_for_each_entry(c, &ctxt.iface->dhcpv4_leases, head) {
-				if (!(c->flags & OAF_BOUND))
-					continue;
-
-				char ipbuf[INET_ADDRSTRLEN];
-				struct in_addr addr = {.s_addr = c->addr};
-				inet_ntop(AF_INET, &addr, ipbuf, sizeof(ipbuf) - 1);
-
-				if (c->hostname && !(c->flags & OAF_BROKEN_HOSTNAME)) {
-					fputs(ipbuf, ctxt.fp);
-
-					char b[256];
-
-					if (dn_expand(ctxt.iface->search,
-							ctxt.iface->search + ctxt.iface->search_len,
-							ctxt.iface->search, b, sizeof(b)) > 0)
-						fprintf(ctxt.fp, "\t%s.%s", c->hostname, b);
-
-					fprintf(ctxt.fp, "\t%s\n", c->hostname);
-				}
-			}
-		}
-	}
-
-	fclose(ctxt.fp);
-
-	rename(tmp_hostsfile, config.dhcp_hostsfile);
-}
-
-void dhcpv6_ia_write_statefile(void)
-{
-	struct write_ctxt ctxt;
-
-	md5_begin(&ctxt.md5);
-
-	if (config.dhcp_statefile) {
-		unsigned statefile_strlen = strlen(config.dhcp_statefile) + 1;
-		unsigned tmp_statefile_strlen = statefile_strlen + 1; /* space for . */
-		char *tmp_statefile = alloca(tmp_statefile_strlen);
-
-		char *dir_statefile;
-		char *base_statefile;
-		char *pdir_statefile;
-		char *pbase_statefile;
-
-		time_t now = odhcpd_time(), wall_time = time(NULL);
-		int fd, ret;
-		char leasebuf[512];
-
-		dir_statefile = strndup(config.dhcp_statefile, statefile_strlen);
-		base_statefile = strndup(config.dhcp_statefile, statefile_strlen);
-
-		pdir_statefile = dirname(dir_statefile);
-		pbase_statefile = basename(base_statefile);
-
-		snprintf(tmp_statefile, tmp_statefile_strlen, "%s/.%s", pdir_statefile, pbase_statefile);
-
-		free(dir_statefile);
-		free(base_statefile);
-
-		fd = open(tmp_statefile, O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
-		if (fd < 0)
-			return;
-
-		ret = lockf(fd, F_LOCK, 0);
-		if (ret < 0) {
-			close(fd);
-			return;
-		}
-
-		if (ftruncate(fd, 0) < 0) {}
-
-		ctxt.fp = fdopen(fd, "w");
-		if (!ctxt.fp) {
-			close(fd);
-			return;
-		}
-
-		ctxt.buf = leasebuf;
-		ctxt.buf_len = sizeof(leasebuf);
-
-		avl_for_each_element(&interfaces, ctxt.iface, avl) {
-			if (ctxt.iface->dhcpv6 != MODE_SERVER &&
-					ctxt.iface->dhcpv4 != MODE_SERVER)
-				continue;
-
-			if (ctxt.iface->dhcpv6 == MODE_SERVER) {
-				list_for_each_entry(ctxt.c, &ctxt.iface->ia_assignments, head) {
-					if (!(ctxt.c->flags & OAF_BOUND))
-						continue;
-
-					char duidbuf[DUID_HEXSTRLEN];
-
-					odhcpd_hexlify(duidbuf, ctxt.c->clid_data, ctxt.c->clid_len);
-
-					/* iface DUID iaid hostname lifetime assigned_host_id length [addrs...] */
-					ctxt.buf_idx = snprintf(ctxt.buf, ctxt.buf_len, "# %s %s %x %s%s %"PRId64" ",
-								ctxt.iface->ifname, duidbuf, ntohl(ctxt.c->iaid),
-								(ctxt.c->flags & OAF_BROKEN_HOSTNAME) ? "broken\\x20" : "",
-								(ctxt.c->hostname ? ctxt.c->hostname : "-"),
-								(ctxt.c->valid_until > now ?
-									(int64_t)(ctxt.c->valid_until - now + wall_time) :
-									(INFINITE_VALID(ctxt.c->valid_until) ? -1 : 0)));
-
-					if (ctxt.c->flags & OAF_DHCPV6_NA)
-						ctxt.buf_idx += snprintf(ctxt.buf + ctxt.buf_idx, ctxt.buf_len - ctxt.buf_idx,
-									 "%" PRIx64" %u ", ctxt.c->assigned_host_id, (unsigned)ctxt.c->length);
-					else
-						ctxt.buf_idx += snprintf(ctxt.buf + ctxt.buf_idx, ctxt.buf_len - ctxt.buf_idx,
-									 "%" PRIx32" %u ", ctxt.c->assigned_subnet_id, (unsigned)ctxt.c->length);
-
-					if (INFINITE_VALID(ctxt.c->valid_until) || ctxt.c->valid_until > now)
-						dhcpv6_ia_enum_addrs(ctxt.iface, ctxt.c, now,
-									dhcpv6_write_ia_addr, &ctxt);
-
-					ctxt.buf[ctxt.buf_idx - 1] = '\n';
-					fwrite(ctxt.buf, 1, ctxt.buf_idx, ctxt.fp);
-				}
-			}
-
-			if (ctxt.iface->dhcpv4 == MODE_SERVER) {
-				struct dhcpv4_lease *c;
-
-				list_for_each_entry(c, &ctxt.iface->dhcpv4_leases, head) {
-					if (!(c->flags & OAF_BOUND))
-						continue;
-
-					char ipbuf[INET6_ADDRSTRLEN];
-					char duidbuf[16];
-					odhcpd_hexlify(duidbuf, c->hwaddr, sizeof(c->hwaddr));
-
-					/* iface DUID iaid hostname lifetime assigned length [addrs...] */
-					ctxt.buf_idx = snprintf(ctxt.buf, ctxt.buf_len, "# %s %s ipv4 %s%s %"PRId64" %x 32 ",
-								ctxt.iface->ifname, duidbuf,
-								(c->flags & OAF_BROKEN_HOSTNAME) ? "broken\\x20" : "",
-								(c->hostname ? c->hostname : "-"),
-								(c->valid_until > now ?
-									(int64_t)(c->valid_until - now + wall_time) :
-									(INFINITE_VALID(c->valid_until) ? -1 : 0)),
-								ntohl(c->addr));
-
-					struct in_addr addr = {.s_addr = c->addr};
-					inet_ntop(AF_INET, &addr, ipbuf, sizeof(ipbuf) - 1);
-
-					if (c->hostname && !(c->flags & OAF_BROKEN_HOSTNAME)) {
-						fputs(ipbuf, ctxt.fp);
-
-						char b[256];
-						if (dn_expand(ctxt.iface->search,
-								ctxt.iface->search + ctxt.iface->search_len,
-								ctxt.iface->search, b, sizeof(b)) > 0)
-							fprintf(ctxt.fp, "\t%s.%s", c->hostname, b);
-
-						fprintf(ctxt.fp, "\t%s\n", c->hostname);
-						md5_hash(ipbuf, strlen(ipbuf), &ctxt.md5);
-						md5_hash(c->hostname, strlen(c->hostname), &ctxt.md5);
-					}
-
-					ctxt.buf_idx += snprintf(ctxt.buf + ctxt.buf_idx,
-									ctxt.buf_len - ctxt.buf_idx,
-									"%s/32 ", ipbuf);
-					ctxt.buf[ctxt.buf_idx - 1] = '\n';
-					fwrite(ctxt.buf, 1, ctxt.buf_idx, ctxt.fp);
-				}
-			}
-		}
-
-		fclose(ctxt.fp);
-
-		uint8_t newmd5[16];
-		md5_end(newmd5, &ctxt.md5);
-
-		rename(tmp_statefile, config.dhcp_statefile);
-
-		if (memcmp(newmd5, statemd5, sizeof(newmd5))) {
-			memcpy(statemd5, newmd5, sizeof(statemd5));
-
-			if (config.dhcp_hostsfile)
-				dhcpv6_ia_write_hostsfile(now);
-
-			if (config.dhcp_cb) {
-				char *argv[2] = {config.dhcp_cb, NULL};
-				if (!vfork()) {
-					execv(argv[0], argv);
-					_exit(128);
-				}
-			}
-		}
-	}
 }
 
 static void __apply_lease(struct dhcpv6_lease *a,

--- a/src/dhcpv6-ia.h
+++ b/src/dhcpv6-ia.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2013 Steven Barth <steven@midlink.org>
+ * Copyright (C) 2016 Hans Dedecker <dedeckeh@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License v2 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef _DHCPV6_IA_H_
+#define _DHCPV6_IA_H_
+
+#define ADDR_ENTRY_VALID_IA_ADDR(iface, i, m, addrs) \
+    ((iface)->dhcpv6_assignall || (i) == (m) || \
+     (addrs)[(i)].prefix > 64)
+
+size_t get_preferred_addr(const struct odhcpd_ipaddr *addrs, const size_t addrlen);
+
+struct in6_addr in6_from_prefix_and_iid(const struct odhcpd_ipaddr *prefix, uint64_t iid);
+
+static inline bool valid_prefix_length(const struct dhcpv6_lease *a, const uint8_t prefix_length)
+{
+	return a->length > prefix_length;
+}
+
+static inline bool valid_addr(const struct odhcpd_ipaddr *addr, time_t now)
+{
+	return (addr->prefix <= 96 && addr->valid_lt > (uint32_t)now && addr->preferred_lt > (uint32_t)now);
+}
+
+#endif /* _DHCPV6_IA_H_ */

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -200,7 +200,7 @@ struct config {
 
 	char *dhcp_statefile;
 	int dhcp_statedir_fd;
-	char *dhcp_hostsfile;
+	char *dhcp_hostsdir;
 	int dhcp_hostsdir_fd;
 
 	char *ra_piofolder;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -534,11 +534,12 @@ const char *odhcpd_print_mac(const uint8_t *mac, const size_t len);
 int odhcpd_bmemcmp(const void *av, const void *bv, size_t bits);
 void odhcpd_bmemcpy(void *av, const void *bv, size_t bits);
 
-typedef void (*dhcpv6_binding_cb_handler_t)(struct dhcpv6_lease *lease,
-					    struct in6_addr *addr, int prefix,
-					    uint32_t pref, uint32_t valid,
-					    void *arg);
-
+typedef void (*odhcpd_enum_addr6_cb_t)(struct dhcpv6_lease *lease,
+				       struct in6_addr *addr, int prefix,
+				       uint32_t pref, uint32_t valid,
+				       void *arg);
+void odhcpd_enum_addr6(struct interface *iface, struct dhcpv6_lease *lease,
+		       time_t now, odhcpd_enum_addr6_cb_t func, void *arg);
 int odhcpd_parse_addr6_prefix(const char *str, struct in6_addr *addr, uint8_t *prefix);
 int odhcpd_netmask2bitlen(bool v6, void *mask);
 bool odhcpd_bitlen2netmask(bool v6, unsigned int bits, void *mask);

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -99,10 +99,6 @@ typedef	ssize_t (*send_reply_cb_t)(struct iovec *iov, size_t iov_len,
 				   struct sockaddr *dest, socklen_t dest_len,
 				   void *opaque);
 
-typedef void (*dhcpv6_binding_cb_handler_t)(struct in6_addr *addr, int prefix,
-					    uint32_t pref, uint32_t valid,
-					    void *arg);
-
 union if_addr {
 	struct in_addr in;
 	struct in6_addr in6;
@@ -537,6 +533,11 @@ const char *odhcpd_print_mac(const uint8_t *mac, const size_t len);
 
 int odhcpd_bmemcmp(const void *av, const void *bv, size_t bits);
 void odhcpd_bmemcpy(void *av, const void *bv, size_t bits);
+
+typedef void (*dhcpv6_binding_cb_handler_t)(struct dhcpv6_lease *lease,
+					    struct in6_addr *addr, int prefix,
+					    uint32_t pref, uint32_t valid,
+					    void *arg);
 
 int odhcpd_parse_addr6_prefix(const char *str, struct in6_addr *addr, uint8_t *prefix);
 int odhcpd_netmask2bitlen(bool v6, void *mask);

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -201,7 +201,9 @@ struct config {
 	bool enable_tz;
 	bool main_dhcpv4;
 	char *dhcp_cb;
+
 	char *dhcp_statefile;
+	int dhcp_statedir_fd;
 	char *dhcp_hostsfile;
 	int dhcp_hostsdir_fd;
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -584,9 +584,6 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 int dhcpv6_ia_init(void);
 int dhcpv6_ia_setup_interface(struct interface *iface, bool enable);
 void dhcpv6_free_lease(struct dhcpv6_lease *lease);
-void dhcpv6_ia_enum_addrs(struct interface *iface, struct dhcpv6_lease *lease,
-			  time_t now, dhcpv6_binding_cb_handler_t func, void *arg);
-void dhcpv6_ia_write_statefile(void);
 
 int netlink_add_netevent_handler(struct netevent_handler *hdlr);
 ssize_t netlink_get_interface_addrs(const int ifindex, bool v6,

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -203,6 +203,7 @@ struct config {
 	char *dhcp_cb;
 	char *dhcp_statefile;
 	char *dhcp_hostsfile;
+	int dhcp_hostsdir_fd;
 
 	char *ra_piofolder;
 	int ra_piofolder_fd;

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -1,0 +1,400 @@
+/*
+ * SPDX-FileCopyrightText: 2013 Steven Barth <steven@midlink.org>
+ * SPDX-FileCopyrightText: 2013 Hans Dedecker <dedeckeh@gmail.com>
+ * SPDX-FileCopyrightText: 2022 Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
+ * SPDX-FileCopyrightText: 2024 Paul Donald <newtwen@gmail.com>
+ * SPDX-FileCopyrightText: 2024 David Härdeman <david@hardeman.nu>
+ *
+ * SPDX-License-Identifier: GPL2.0-only
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <libgen.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <time.h>
+#include <netinet/in.h>
+#include <arpa/nameser.h>
+#include <arpa/inet.h>
+#include <resolv.h>
+
+#include <libubox/md5.h>
+
+#include "odhcpd.h"
+#include "dhcpv6-ia.h"
+#include "statefiles.h"
+
+static uint8_t statemd5[16];
+
+void dhcpv6_ia_enum_addrs(struct interface *iface, struct dhcpv6_lease *c,
+			  time_t now, dhcpv6_binding_cb_handler_t func, void *arg)
+{
+	struct odhcpd_ipaddr *addrs = iface->addr6;
+	size_t m = get_preferred_addr(addrs, iface->addr6_len);
+
+	for (size_t i = 0; i < iface->addr6_len; ++i) {
+		struct in6_addr addr;
+		uint32_t preferred_lt, valid_lt;
+		int prefix = c->length;
+
+		if (!valid_addr(&addrs[i], now))
+			continue;
+
+		/* Filter Out Prefixes */
+		if (ADDR_MATCH_PIO_FILTER(&addrs[i], iface)) {
+			char addrbuf[INET6_ADDRSTRLEN];
+			info("Address %s filtered out on %s",
+			     inet_ntop(AF_INET6, &addrs[i].addr.in6, addrbuf, sizeof(addrbuf)),
+			     iface->name);
+			continue;
+		}
+
+		if (c->flags & OAF_DHCPV6_NA) {
+			if (!ADDR_ENTRY_VALID_IA_ADDR(iface, i, m, addrs))
+				continue;
+
+			addr = in6_from_prefix_and_iid(&addrs[i], c->assigned_host_id);
+		} else {
+			if (!valid_prefix_length(c, addrs[i].prefix))
+				continue;
+
+			addr = addrs[i].addr.in6;
+			addr.s6_addr32[1] |= htonl(c->assigned_subnet_id);
+			addr.s6_addr32[2] = addr.s6_addr32[3] = 0;
+		}
+
+		preferred_lt = addrs[i].preferred_lt;
+		if (preferred_lt > (uint32_t)c->preferred_until)
+			preferred_lt = c->preferred_until;
+
+		if (preferred_lt > (uint32_t)c->valid_until)
+			preferred_lt = c->valid_until;
+
+		if (preferred_lt != UINT32_MAX)
+			preferred_lt -= now;
+
+		valid_lt = addrs[i].valid_lt;
+		if (valid_lt > (uint32_t)c->valid_until)
+			valid_lt = c->valid_until;
+
+		if (valid_lt != UINT32_MAX)
+			valid_lt -= now;
+
+		func(&addr, prefix, preferred_lt, valid_lt, arg);
+	}
+}
+
+struct write_ctxt {
+	FILE *fp;
+	md5_ctx_t md5;
+	struct dhcpv6_lease *c;
+	struct interface *iface;
+	char *buf;
+	int buf_len;
+	int buf_idx;
+};
+
+static void dhcpv6_write_ia_addrhosts(struct in6_addr *addr, int prefix, _unused uint32_t pref_lt,
+				_unused uint32_t valid_lt, void *arg)
+{
+	struct write_ctxt *ctxt = (struct write_ctxt *)arg;
+	char ipbuf[INET6_ADDRSTRLEN];
+
+	if ((ctxt->c->flags & OAF_DHCPV6_NA) && ctxt->c->hostname &&
+	    !(ctxt->c->flags & OAF_BROKEN_HOSTNAME)) {
+		inet_ntop(AF_INET6, addr, ipbuf, sizeof(ipbuf) - 1);
+		fputs(ipbuf, ctxt->fp);
+
+		char b[256];
+		if (dn_expand(ctxt->iface->search, ctxt->iface->search + ctxt->iface->search_len,
+				ctxt->iface->search, b, sizeof(b)) > 0)
+			fprintf(ctxt->fp, "\t%s.%s", ctxt->c->hostname, b);
+
+		fprintf(ctxt->fp, "\t%s\n", ctxt->c->hostname);
+	}
+}
+
+static void dhcpv6_write_ia_addr(struct in6_addr *addr, int prefix, _unused uint32_t pref_lt,
+				_unused uint32_t valid_lt, void *arg)
+{
+	struct write_ctxt *ctxt = (struct write_ctxt *)arg;
+	char ipbuf[INET6_ADDRSTRLEN];
+
+	inet_ntop(AF_INET6, addr, ipbuf, sizeof(ipbuf) - 1);
+
+	if ((ctxt->c->flags & OAF_DHCPV6_NA) && ctxt->c->hostname &&
+	    !(ctxt->c->flags & OAF_BROKEN_HOSTNAME)) {
+		fputs(ipbuf, ctxt->fp);
+
+		char b[256];
+		if (dn_expand(ctxt->iface->search, ctxt->iface->search + ctxt->iface->search_len,
+				ctxt->iface->search, b, sizeof(b)) > 0)
+			fprintf(ctxt->fp, "\t%s.%s", ctxt->c->hostname, b);
+
+		fprintf(ctxt->fp, "\t%s\n", ctxt->c->hostname);
+		md5_hash(ipbuf, strlen(ipbuf), &ctxt->md5);
+		md5_hash(ctxt->c->hostname, strlen(ctxt->c->hostname), &ctxt->md5);
+	}
+
+	ctxt->buf_idx += snprintf(ctxt->buf + ctxt->buf_idx,ctxt->buf_len - ctxt->buf_idx,
+					"%s/%d ", ipbuf, prefix);
+}
+
+static void dhcpv6_ia_write_hostsfile(time_t now)
+{
+	struct write_ctxt ctxt;
+
+	unsigned hostsfile_strlen = strlen(config.dhcp_hostsfile) + 1;
+	unsigned tmp_hostsfile_strlen = hostsfile_strlen + 1; /* space for . */
+	char *tmp_hostsfile = alloca(tmp_hostsfile_strlen);
+
+	char *dir_hostsfile;
+	char *base_hostsfile;
+	char *pdir_hostsfile;
+	char *pbase_hostsfile;
+
+	int fd, ret;
+
+	dir_hostsfile = strndup(config.dhcp_hostsfile, hostsfile_strlen);
+	base_hostsfile = strndup(config.dhcp_hostsfile, hostsfile_strlen);
+
+	pdir_hostsfile = dirname(dir_hostsfile);
+	pbase_hostsfile = basename(base_hostsfile);
+
+	snprintf(tmp_hostsfile, tmp_hostsfile_strlen, "%s/.%s", pdir_hostsfile, pbase_hostsfile);
+
+	free(dir_hostsfile);
+	free(base_hostsfile);
+
+	fd = open(tmp_hostsfile, O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
+	if (fd < 0)
+		return;
+
+	ret = lockf(fd, F_LOCK, 0);
+	if (ret < 0) {
+		close(fd);
+		return;
+	}
+
+	if (ftruncate(fd, 0) < 0) {}
+
+	ctxt.fp = fdopen(fd, "w");
+	if (!ctxt.fp) {
+		close(fd);
+		return;
+	}
+
+	avl_for_each_element(&interfaces, ctxt.iface, avl) {
+		if (ctxt.iface->dhcpv6 != MODE_SERVER &&
+				ctxt.iface->dhcpv4 != MODE_SERVER)
+			continue;
+
+		if (ctxt.iface->dhcpv6 == MODE_SERVER) {
+			list_for_each_entry(ctxt.c, &ctxt.iface->ia_assignments, head) {
+				if (!(ctxt.c->flags & OAF_BOUND))
+					continue;
+
+				if (INFINITE_VALID(ctxt.c->valid_until) || ctxt.c->valid_until > now)
+					dhcpv6_ia_enum_addrs(ctxt.iface, ctxt.c, now,
+							     dhcpv6_write_ia_addrhosts, &ctxt);
+			}
+		}
+
+		if (ctxt.iface->dhcpv4 == MODE_SERVER) {
+			struct dhcpv4_lease *c;
+
+			list_for_each_entry(c, &ctxt.iface->dhcpv4_leases, head) {
+				if (!(c->flags & OAF_BOUND))
+					continue;
+
+				char ipbuf[INET_ADDRSTRLEN];
+				struct in_addr addr = {.s_addr = c->addr};
+				inet_ntop(AF_INET, &addr, ipbuf, sizeof(ipbuf) - 1);
+
+				if (c->hostname && !(c->flags & OAF_BROKEN_HOSTNAME)) {
+					fputs(ipbuf, ctxt.fp);
+
+					char b[256];
+
+					if (dn_expand(ctxt.iface->search,
+							ctxt.iface->search + ctxt.iface->search_len,
+							ctxt.iface->search, b, sizeof(b)) > 0)
+						fprintf(ctxt.fp, "\t%s.%s", c->hostname, b);
+
+					fprintf(ctxt.fp, "\t%s\n", c->hostname);
+				}
+			}
+		}
+	}
+
+	fclose(ctxt.fp);
+
+	rename(tmp_hostsfile, config.dhcp_hostsfile);
+}
+
+void dhcpv6_ia_write_statefile(void)
+{
+	struct write_ctxt ctxt;
+
+	md5_begin(&ctxt.md5);
+
+	if (config.dhcp_statefile) {
+		unsigned statefile_strlen = strlen(config.dhcp_statefile) + 1;
+		unsigned tmp_statefile_strlen = statefile_strlen + 1; /* space for . */
+		char *tmp_statefile = alloca(tmp_statefile_strlen);
+
+		char *dir_statefile;
+		char *base_statefile;
+		char *pdir_statefile;
+		char *pbase_statefile;
+
+		time_t now = odhcpd_time(), wall_time = time(NULL);
+		int fd, ret;
+		char leasebuf[512];
+
+		dir_statefile = strndup(config.dhcp_statefile, statefile_strlen);
+		base_statefile = strndup(config.dhcp_statefile, statefile_strlen);
+
+		pdir_statefile = dirname(dir_statefile);
+		pbase_statefile = basename(base_statefile);
+
+		snprintf(tmp_statefile, tmp_statefile_strlen, "%s/.%s", pdir_statefile, pbase_statefile);
+
+		free(dir_statefile);
+		free(base_statefile);
+
+		fd = open(tmp_statefile, O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
+		if (fd < 0)
+			return;
+
+		ret = lockf(fd, F_LOCK, 0);
+		if (ret < 0) {
+			close(fd);
+			return;
+		}
+
+		if (ftruncate(fd, 0) < 0) {}
+
+		ctxt.fp = fdopen(fd, "w");
+		if (!ctxt.fp) {
+			close(fd);
+			return;
+		}
+
+		ctxt.buf = leasebuf;
+		ctxt.buf_len = sizeof(leasebuf);
+
+		avl_for_each_element(&interfaces, ctxt.iface, avl) {
+			if (ctxt.iface->dhcpv6 != MODE_SERVER &&
+					ctxt.iface->dhcpv4 != MODE_SERVER)
+				continue;
+
+			if (ctxt.iface->dhcpv6 == MODE_SERVER) {
+				list_for_each_entry(ctxt.c, &ctxt.iface->ia_assignments, head) {
+					if (!(ctxt.c->flags & OAF_BOUND))
+						continue;
+
+					char duidbuf[DUID_HEXSTRLEN];
+
+					odhcpd_hexlify(duidbuf, ctxt.c->clid_data, ctxt.c->clid_len);
+
+					/* iface DUID iaid hostname lifetime assigned_host_id length [addrs...] */
+					ctxt.buf_idx = snprintf(ctxt.buf, ctxt.buf_len, "# %s %s %x %s%s %"PRId64" ",
+								ctxt.iface->ifname, duidbuf, ntohl(ctxt.c->iaid),
+								(ctxt.c->flags & OAF_BROKEN_HOSTNAME) ? "broken\\x20" : "",
+								(ctxt.c->hostname ? ctxt.c->hostname : "-"),
+								(ctxt.c->valid_until > now ?
+									(int64_t)(ctxt.c->valid_until - now + wall_time) :
+									(INFINITE_VALID(ctxt.c->valid_until) ? -1 : 0)));
+
+					if (ctxt.c->flags & OAF_DHCPV6_NA)
+						ctxt.buf_idx += snprintf(ctxt.buf + ctxt.buf_idx, ctxt.buf_len - ctxt.buf_idx,
+									 "%" PRIx64" %u ", ctxt.c->assigned_host_id, (unsigned)ctxt.c->length);
+					else
+						ctxt.buf_idx += snprintf(ctxt.buf + ctxt.buf_idx, ctxt.buf_len - ctxt.buf_idx,
+									 "%" PRIx32" %u ", ctxt.c->assigned_subnet_id, (unsigned)ctxt.c->length);
+
+					if (INFINITE_VALID(ctxt.c->valid_until) || ctxt.c->valid_until > now)
+						dhcpv6_ia_enum_addrs(ctxt.iface, ctxt.c, now,
+									dhcpv6_write_ia_addr, &ctxt);
+
+					ctxt.buf[ctxt.buf_idx - 1] = '\n';
+					fwrite(ctxt.buf, 1, ctxt.buf_idx, ctxt.fp);
+				}
+			}
+
+			if (ctxt.iface->dhcpv4 == MODE_SERVER) {
+				struct dhcpv4_lease *c;
+
+				list_for_each_entry(c, &ctxt.iface->dhcpv4_leases, head) {
+					if (!(c->flags & OAF_BOUND))
+						continue;
+
+					char ipbuf[INET6_ADDRSTRLEN];
+					char duidbuf[16];
+					odhcpd_hexlify(duidbuf, c->hwaddr, sizeof(c->hwaddr));
+
+					/* iface DUID iaid hostname lifetime assigned length [addrs...] */
+					ctxt.buf_idx = snprintf(ctxt.buf, ctxt.buf_len, "# %s %s ipv4 %s%s %"PRId64" %x 32 ",
+								ctxt.iface->ifname, duidbuf,
+								(c->flags & OAF_BROKEN_HOSTNAME) ? "broken\\x20" : "",
+								(c->hostname ? c->hostname : "-"),
+								(c->valid_until > now ?
+									(int64_t)(c->valid_until - now + wall_time) :
+									(INFINITE_VALID(c->valid_until) ? -1 : 0)),
+								ntohl(c->addr));
+
+					struct in_addr addr = {.s_addr = c->addr};
+					inet_ntop(AF_INET, &addr, ipbuf, sizeof(ipbuf) - 1);
+
+					if (c->hostname && !(c->flags & OAF_BROKEN_HOSTNAME)) {
+						fputs(ipbuf, ctxt.fp);
+
+						char b[256];
+						if (dn_expand(ctxt.iface->search,
+								ctxt.iface->search + ctxt.iface->search_len,
+								ctxt.iface->search, b, sizeof(b)) > 0)
+							fprintf(ctxt.fp, "\t%s.%s", c->hostname, b);
+
+						fprintf(ctxt.fp, "\t%s\n", c->hostname);
+						md5_hash(ipbuf, strlen(ipbuf), &ctxt.md5);
+						md5_hash(c->hostname, strlen(c->hostname), &ctxt.md5);
+					}
+
+					ctxt.buf_idx += snprintf(ctxt.buf + ctxt.buf_idx,
+									ctxt.buf_len - ctxt.buf_idx,
+									"%s/32 ", ipbuf);
+					ctxt.buf[ctxt.buf_idx - 1] = '\n';
+					fwrite(ctxt.buf, 1, ctxt.buf_idx, ctxt.fp);
+				}
+			}
+		}
+
+		fclose(ctxt.fp);
+
+		uint8_t newmd5[16];
+		md5_end(newmd5, &ctxt.md5);
+
+		rename(tmp_statefile, config.dhcp_statefile);
+
+		if (memcmp(newmd5, statemd5, sizeof(newmd5))) {
+			memcpy(statemd5, newmd5, sizeof(statemd5));
+
+			if (config.dhcp_hostsfile)
+				dhcpv6_ia_write_hostsfile(now);
+
+			if (config.dhcp_cb) {
+				char *argv[2] = {config.dhcp_cb, NULL};
+				if (!vfork()) {
+					execv(argv[0], argv);
+					_exit(128);
+				}
+			}
+		}
+	}
+}
+

--- a/src/statefiles.h
+++ b/src/statefiles.h
@@ -7,9 +7,6 @@
 #ifndef _STATEFILES_H_
 #define _STATEFILES_H_
 
-void dhcpv6_ia_enum_addrs(struct interface *iface, struct dhcpv6_lease *lease,
-			  time_t now, dhcpv6_binding_cb_handler_t func, void *arg);
-
 bool statefiles_write(void);
 
 #endif /* _STATEFILES_H_ */

--- a/src/statefiles.h
+++ b/src/statefiles.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2024 David Härdeman <david@hardeman.nu>
+ *
+ * SPDX-License-Identifier: GPL2.0-only
+ */
+
+#ifndef _STATEFILES_H_
+#define _STATEFILES_H_
+
+void dhcpv6_ia_enum_addrs(struct interface *iface, struct dhcpv6_lease *lease,
+			  time_t now, dhcpv6_binding_cb_handler_t func, void *arg);
+
+void dhcpv6_ia_write_statefile(void);
+
+#endif /* _STATEFILES_H_ */

--- a/src/statefiles.h
+++ b/src/statefiles.h
@@ -7,6 +7,8 @@
 #ifndef _STATEFILES_H_
 #define _STATEFILES_H_
 
+#define ODHCPD_HOSTS_FILE_PREFIX "odhcpd.hosts"
+
 bool statefiles_write(void);
 
 #endif /* _STATEFILES_H_ */

--- a/src/statefiles.h
+++ b/src/statefiles.h
@@ -10,6 +10,6 @@
 void dhcpv6_ia_enum_addrs(struct interface *iface, struct dhcpv6_lease *lease,
 			  time_t now, dhcpv6_binding_cb_handler_t func, void *arg);
 
-void dhcpv6_ia_write_statefile(void);
+bool statefiles_write(void);
 
 #endif /* _STATEFILES_H_ */

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -84,8 +84,8 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _unused struct ubus_ob
 }
 #endif /* DHCPV4_SUPPORT */
 
-static void dhcpv6_blobmsg_ia_addr(struct in6_addr *addr, int prefix, uint32_t pref,
-					uint32_t valid, _unused void *arg)
+static void dhcpv6_blobmsg_ia_addr(_unused struct dhcpv6_lease *lease, struct in6_addr *addr, int prefix,
+				   uint32_t pref_lt, uint32_t valid_lt, _unused void *arg)
 {
 	void *a	= blobmsg_open_table(&b, NULL);
 	char *buf = blobmsg_alloc_string_buffer(&b, "address", INET6_ADDRSTRLEN);
@@ -93,9 +93,9 @@ static void dhcpv6_blobmsg_ia_addr(struct in6_addr *addr, int prefix, uint32_t p
 	inet_ntop(AF_INET6, addr, buf, INET6_ADDRSTRLEN);
 	blobmsg_add_string_buffer(&b);
 	blobmsg_add_u32(&b, "preferred-lifetime",
-			pref == UINT32_MAX ? (uint32_t)-1 : pref);
+			pref_lt == UINT32_MAX ? (uint32_t)-1 : pref_lt);
 	blobmsg_add_u32(&b, "valid-lifetime",
-			valid == UINT32_MAX ? (uint32_t)-1 : valid);
+			valid_lt == UINT32_MAX ? (uint32_t)-1 : valid_lt);
 
 	if (prefix != 128)
 		blobmsg_add_u32(&b, "prefix-length", prefix);

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -9,6 +9,7 @@
 #include "odhcpd.h"
 #include "dhcpv6.h"
 #include "dhcpv4.h"
+#include "statefiles.h"
 
 static struct ubus_context *ubus = NULL;
 static struct ubus_subscriber netifd;

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -153,7 +153,7 @@ static int handle_dhcpv6_leases(_unused struct ubus_context *ctx, _unused struct
 			blobmsg_close_array(&b, m);
 
 			m = blobmsg_open_array(&b, a->flags & OAF_DHCPV6_NA ? "ipv6-addr": "ipv6-prefix");
-			dhcpv6_ia_enum_addrs(iface, a, now, dhcpv6_blobmsg_ia_addr, NULL);
+			odhcpd_enum_addr6(iface, a, now, dhcpv6_blobmsg_ia_addr, NULL);
 			blobmsg_close_array(&b, m);
 
 			blobmsg_add_u32(&b, "valid", INFINITE_VALID(a->valid_until) ?


### PR DESCRIPTION
The gist is that state and hosts file writing is moved from `src/dhcpv6-ia.c` into a separate file `src/statefiles.c` (since state and hosts file writing is something which is used by both the DHCPv4 and DHCPv6 servers). This also makes `src/dhcpv6-ia.c` a bit easier to work with (shrinking it from ~1700 lines to ~1300 lines, my rule of thumb is that files start getting difficult to grok when they exceed 1000 lines).

Anyway, there are some important fixes here:
 - Right now, the `hostsfile` cfg option has no effect if `leasefile` isn't set (not documented, but mentioned in 4bbc6e74248feeb756bd03dc500fb4f446ccfc49)
 - If using multiple subnets and instances of `dnsmasq`, there is no way to tell which hosts are available on which subnet, meaning that `dnsmasq` will "leak" the hostnames across subnets (so your guest network can see hosts from other networks, see issue #237
 - With that in mind, the `hostsfile` option is changed to `hostsdir`, where per-interface hosts files will be written

With regard to the `hostsdir` change, note that while `odhcpd` can write a hostsfile as well as a leasefile, the former is typically not used at the moment in a default install. `dnsmasq` will instead read the `leasefile` to get the DNS records.

After this change, `dnsmasq` can be migrated to use the `hostsdir` instead.

dnsmasq already supports reading several hosts files from a directory (via the `--hostsdir=` option), so some changes to dnsmasq's init script will also be necessary (depending on whether the user wants dnsmasq to support resolution of all hosts or just the hosts on a given interface).
    
Making hosts files (rather than odhcpd's lease/state file) the primary interface for dnsmasq is also an important first step towards making the state/leasefile properly private (the other important consumer is LuCI, via its rpcd plugin, I already have some prototype patches to let LuCI get the information by talking to `odhpcd` over ubus instead of parsing its state files), which is necessary if we want to support persisting leases across restarts of odhcpd (or even reboots, if writing to flash is deemed acceptable) in the future (since I want to extend the state/leasefile to capture the full state of leases so that they can be properly reconstructed on reboot/restart).

In addition, the use of `--hostsdir=` in dnsmasq could make the `leasetrigger` unnecessary in the future, since the latter restarts `dnsmasq` to make it aware of the changes to the hostsfile (and `hostsdir` means that `dnsmasq` will monitor the dir with `inotify` and automagically pickup any changes). That still leaves the case when dnsmasq uses multiple instances and only wants to read a specific hostsfile (which, AFAIK, doesn't support automatic detection of when that specific file changes), but that's something to address down the road (the `leasescript` functionality is still there with this PR applied).

There's also a substantial amount of cleanup work to make the statefile code easier to read and parse. There's a log of patches here, and I would suggest that you read the whole diff if you want to save some time, since it'll show the resulting statesfile.c quite nicely.
