### PR TITLE
odhcpd: add support for the "ignore" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ and may also receive information from ubus
 ### Sections of type host (static leases)
 | Option		| Type	|Default| Description |
 | :-------------------- | :---- | :---- | :---------- |
-| ip			|string	|(none) | IPv4 host address |
+| ip			|string	|(none) | IPv4 host address or `ignore` to ignore any DHCPv4 request from this host |
 | mac			|list\|string|(none) | HexadecimalMACaddress(es) |
 | duid			|list\|string|(none) | Hexadecimal DUID(s), or DUID%IAID(s) |
-| hostid		|string	|(none)	| IPv6hostidentifier |
+| hostid		|string	|(none)	| IPv6 tokenised IID or `ignore` to ignore any DHCPv6 request from this host |
 | name			|string	|(none) | Hostname |
 | leasetime		|string	|(none) | DHCPv4/v6leasetime |
 

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -534,6 +534,9 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg req_msg, const uint8_t *re
 	if (!lease_cfg)
 		lease_cfg = config_find_lease_cfg_by_mac(req_mac);
 
+	if (lease_cfg && lease_cfg->ignore4)
+		return NULL;
+
 	/*
 	 * If we found a static lease cfg, but no old assignment for this
 	 * hwaddr, we need to clear out any old assignments given to other

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -993,6 +993,9 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 		if (!lease_cfg)
 			lease_cfg = config_find_lease_cfg_by_mac(mac);
 
+		if (lease_cfg && lease_cfg->ignore6)
+			return -1;
+
 		/* Parse request hint for IA-PD */
 		if (is_pd) {
 			uint8_t *sdata;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -302,6 +302,8 @@ struct lease_cfg {
 	struct duid *duids;
 	uint32_t leasetime;		// duration of granted leases, UINT32_MAX = inf
 	char *hostname;
+	bool ignore4;
+	bool ignore6;
 };
 
 // DNR - RFC9463


### PR DESCRIPTION
This is inspired by @Kasoo's work in PR https://github.com/openwrt/odhcpd/pull/234, but slightly different.

The "ip" option now takes "ignore" as a value , but it'll only disable DHCPv4 for a matching client.

Similarly, the "hostid" option now also understands "ignore", which will disable DHCPv6 for a matching client.

Of course, this is all based on client-reported MAC addresses/DUIDs/client IDs/etc, so it's not exactly a security feature.

Closes: https://github.com/openwrt/odhcpd/pull/234
Closes: https://github.com/openwrt/odhcpd/issues/198

Draft for now, since it's based on top of #299, which needs to go in first.