### PR TITLE
dhcpv6-ia: add missing limits header

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -21,6 +21,7 @@
 
 #include <time.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <resolv.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fix the following build error by including <limits.h>:

```
src/dhcpv6-ia.c: In function 'handle_addrlist_change':
src/dhcpv6-ia.c:495:53: 0
error: 'INT_MAX' undeclared (first use in this function)
  495 |                                         a->fr_cnt = INT_MAX;
      |                                                     ^~~~~~~
src/dhcpv6-ia.c:33:1: note: 'INT_MAX' is defined in header '<limits.h>'; did you forget to '#include <limits.h>'?
   32 | #include <libubox/md5.h>
  +++ |+#include <limits.h>
   33 |
src/dhcpv6-ia.c:495:53: note: each undeclared identifier is reported only once for each function it appears in
  495 |                                         a->fr_cnt = INT_MAX;
      |                                                     ^~~~~~~
```

Note: I found this when trying to build odhcpd with OpenWrt SDK.

CC @Alphix @systemcrash