### PR TITLE
odhcpd: ubus and uloop fixes

### DIFF
--- a/scripts/devel-build.sh
+++ b/scripts/devel-build.sh
@@ -11,7 +11,7 @@ if [ ! -e "CMakeLists.txt" ] || [ ! -e "src/odhcpd.c" ]; then
 fi
 
 if [ $# -eq 0 ]; then
-	BUILD_ARGS="-DDHCPV4_SUPPORT=ON"
+	BUILD_ARGS="-DDHCPV4_SUPPORT=ON -WITH_UBUS=ON"
 else
 	BUILD_ARGS="$@"
 fi

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -67,7 +67,7 @@ void __iflog(int lvl, const char *fmt, ...)
 	va_end(ap);
 }
 
-static void print_usage(const char *app)
+_o_noreturn static void print_usage(const char *app, int exit_status)
 {
 	printf("== %s Usage ==\n"
 	       "Features: ra ndp dhcpv6"
@@ -86,8 +86,13 @@ static void print_usage(const char *app)
 	       "	-c <dir>	Read UCI configuration files from <dir>\n"
 	       "	-l <int>	Specify log level 0..7 (default %d)\n"
 	       "	-f		Log to stderr instead of syslog\n"
+#ifdef WITH_UBUS
+	       "	-u		Disable ubus support\n"
+#endif /* WITH_UBUS */
 	       "	-h		Print this help text and exit\n",
 	       app, config.log_level);
+
+	exit(exit_status);
 }
 
 static bool ipv6_enabled(void)
@@ -106,7 +111,7 @@ int main(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt(argc, argv, "c:l:fh")) != -1) {
+	while ((opt = getopt(argc, argv, "c:l:fuh")) != -1) {
 		switch (opt) {
 		case 'c':
 			struct stat sb;
@@ -135,9 +140,15 @@ int main(int argc, char **argv)
 			config.log_syslog = false;
 			fprintf(stderr, "Logging to stderr\n");
 			break;
+		case 'u':
+			config.use_ubus = false;
+			fprintf(stderr, "Ubus support disabled\n");
+			break;
 		case 'h':
-			print_usage(argv[0]);
-			return 0;
+			print_usage(argv[0], EXIT_SUCCESS);
+		case '?':
+		default:
+			print_usage(argv[0], EXIT_FAILURE);
 		}
 	}
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -536,7 +536,7 @@ int odhcpd_get_flags(const struct interface *iface);
 struct interface* odhcpd_get_interface_by_index(int ifindex);
 void odhcpd_urandom(void *data, size_t len);
 
-void odhcpd_run(void);
+int odhcpd_run(void);
 time_t odhcpd_time(void);
 ssize_t odhcpd_unhexlify(uint8_t *dst, size_t len, const char *src);
 void odhcpd_hexlify(char *dst, const uint8_t *src, size_t len);

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -65,6 +65,10 @@
 #define _o_unused __attribute__((unused))
 #endif /* _o_unused */
 
+#ifndef _o_noreturn
+#define _o_noreturn __attribute__((__noreturn__))
+#endif /* _o_noreturn */
+
 #define ALL_IPV6_NODES "ff02::1"
 #define ALL_IPV6_ROUTERS "ff02::2"
 
@@ -202,10 +206,10 @@ enum duid_type {
 };
 
 struct config {
-	bool legacy;
 	bool enable_tz;
 	bool main_dhcpv4;
 	char *dhcp_cb;
+	bool use_ubus;
 
 	char *dhcp_statefile;
 	int dhcp_statedir_fd;
@@ -580,9 +584,19 @@ static inline int ubus_init(void)
 	return 0;
 }
 
+static inline const char *ubus_get_ifname(const char *name)
+{
+	return NULL;
+}
+
 static inline void ubus_apply_network(void)
 {
 	return;
+}
+
+static inline bool ubus_has_prefix(const char *name, const char *ifname)
+{
+	return false;
 }
 
 static inline

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -473,7 +473,7 @@ bool ubus_has_prefix(const char *name, const char *ifname)
 	unsigned rem;
 
 	if (!dump)
-		return NULL;
+		return false;
 
 	blobmsg_for_each_attr(c, dump, rem) {
 		struct blob_attr *tb[IFACE_ATTR_MAX];


### PR DESCRIPTION
This all started with me getting frustrated that `odhcpd` would go into an unkillable (well, `kill -9` works, of course) loop when built with `ubus`. So one patch adds some developer convenience by allowing `ubus` to be disabled at runtime even if it is built in.

The other patch improves the `uloop` signal handling so that we don't end up in unkillable loop and don't do a bunch of unnecessary work.