### PR TITLE
dhcpv4: use BPF to filter incoming requests

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -372,9 +372,7 @@ static void close_interface(struct interface *iface)
 	router_setup_interface(iface, false);
 	dhcpv6_setup_interface(iface, false);
 	ndp_setup_interface(iface, false);
-#ifdef DHCPV4_SUPPORT
 	dhcpv4_setup_interface(iface, false);
-#endif
 
 	/* make sure timer is not on the timeouts list before freeing */
 	uloop_timeout_cancel(&iface->timer_rs);
@@ -1918,17 +1916,13 @@ void reload_services(struct interface *iface)
 		router_setup_interface(iface, iface->ra != MODE_DISABLED);
 		dhcpv6_setup_interface(iface, iface->dhcpv6 != MODE_DISABLED);
 		ndp_setup_interface(iface, iface->ndp != MODE_DISABLED);
-#ifdef DHCPV4_SUPPORT
 		dhcpv4_setup_interface(iface, iface->dhcpv4 != MODE_DISABLED);
-#endif
 	} else {
 		debug("Disabling services with %s not running", iface->ifname);
 		router_setup_interface(iface, false);
 		dhcpv6_setup_interface(iface, false);
 		ndp_setup_interface(iface, false);
-#ifdef DHCPV4_SUPPORT
 		dhcpv4_setup_interface(iface, false);
-#endif
 	}
 }
 

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1442,7 +1442,7 @@ bool dhcpv4_setup_interface(struct interface *iface, bool enable)
 		.sin_port = htons(DHCPV4_SERVER_PORT),
 		.sin_addr = { INADDR_ANY },
 	};
-	int val = 1;
+	int val;
 	int fd;
 
 	if (iface->dhcpv4_event.uloop.fd >= 0) {
@@ -1465,7 +1465,7 @@ bool dhcpv4_setup_interface(struct interface *iface, bool enable)
 		goto error;
 	}
 
-	/* Basic IPv4 configuration */
+	val = 1;
 	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) < 0) {
 		error("setsockopt(SO_REUSEADDR): %m");
 		goto error;

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1488,7 +1488,7 @@ int dhcpv4_setup_interface(struct interface *iface, bool enable)
 		goto out;
 	}
 
-	val = IPTOS_PREC_INTERNETCONTROL;
+	val = IPTOS_CLASS_CS6;
 	if (setsockopt(iface->dhcpv4_event.uloop.fd, IPPROTO_IP, IP_TOS, &val,
 		       sizeof(val)) < 0) {
 		error("setsockopt(IP_TOS): %m");

--- a/src/dhcpv4.h
+++ b/src/dhcpv4.h
@@ -22,6 +22,7 @@
 #define DHCPV4_FLAG_BROADCAST 0x8000
 
 // RFC951, §3; RFC1542, §2.1; RFC2131, §2
+// draft-ietf-dhc-implementation-02, §4.19.1
 #define DHCPV4_MIN_PACKET_SIZE 300
 
 #define DHCPV4_FR_MIN_DELAY	500

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -644,11 +644,15 @@ int ndp_init(void);
 #ifdef DHCPV4_SUPPORT
 int dhcpv4_init(void);
 void dhcpv4_free_lease(struct dhcpv4_lease *a);
-int dhcpv4_setup_interface(struct interface *iface, bool enable);
+bool dhcpv4_setup_interface(struct interface *iface, bool enable);
 void dhcpv4_handle_msg(void *addr, void *data, size_t len,
 		       struct interface *iface, _o_unused void *dest_addr,
 		       send_reply_cb_t send_reply, void *opaque);
 #else
+static inline bool dhcpv4_setup_interface(struct interface *iface, bool enable) {
+	return true;
+}
+
 static inline void dhcpv4_free_lease(struct dhcpv4_lease *lease) {
 	error("Trying to free IPv4 assignment 0x%p", lease);
 }


### PR DESCRIPTION
This uses a BPF to let the kernel do the preliminary checks for us, meaning `odhcpd` won't have to care about some bogus packets and e.g. messages from other DHCP servers.