### PR TITLE
odhcpd: supports rewrite DNS server to local IPv6 DNS server in relay mode

### DIFF
--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -885,7 +885,7 @@ static void relay_server_response(uint8_t *data, size_t len)
 	}
 
 	/* Rewrite DNS servers if requested */
-	if (iface->always_rewrite_dns && dns_ptr && dns_count > 0) {
+	if ((iface->always_rewrite_dns || iface->dns_service) && dns_ptr && dns_count > 0) {
 		if (is_authenticated)
 			return; /* Impossible to rewrite */
 

--- a/src/router.c
+++ b/src/router.c
@@ -1240,7 +1240,7 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 		}
 
 		/* If we have to rewrite DNS entries */
-		if (c->always_rewrite_dns && dns_ptr && dns_count > 0) {
+		if ((c->always_rewrite_dns || c->dns_service) && dns_ptr && dns_count > 0) {
 			const struct in6_addr *rewrite = c->dns;
 			struct in6_addr addr;
 			size_t rewrite_cnt = c->dns_cnt;


### PR DESCRIPTION
Just like server mode.

My ISP provides IPv6 DNS in the RA. In odhcpd relay mode, internal network devices use the IPv6 DNS advertised by the ISP, causing internal DNS requests to bypass OpenWRT's DNS server. Therefore, relay mode needs to support overriding the DNS server.

In relay mode, `dns_service` is false by default, so this change doesn't affect the original logic. A future PR will be given to LuCI to allow modification of `dns_service` in relay mode.
