### PR TITLE
dhcpv6-ia: fix realloc bug

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1236,9 +1236,9 @@ proceed:
 				    hdr->msg_type == DHCPV6_MSG_REQUEST ||
 				    hdr->msg_type == DHCPV6_MSG_REBIND)) {
 				if ((!(a->flags & OAF_STATIC) || !a->hostname) && hostname_len > 0) {
-					char *hostname = realloc(a->hostname, hostname_len + 1);
-					if (hostname) {
-						a->hostname = hostname;
+					char *tmp = realloc(a->hostname, hostname_len + 1);
+					if (tmp) {
+						a->hostname = tmp;
 						memcpy(a->hostname, hostname, hostname_len);
 						a->hostname[hostname_len] = 0;
 


### PR DESCRIPTION
Commit b9db4d7061a08bf82a25222074065cce71973d0c introduced a bug, the "hostname" variable used for the realloc would shadow the real hostname defined at the beginning of the function. Fix this by using a different variable name.