### PR TITLE
dhcpv6-ia: fix a crash when static lease isn't configured

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1077,6 +1077,9 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 				if (is_pd)
 					continue;
 
+				if (!lease_cfg)
+					continue;
+
 				/* Does the existing assignment stem from the same static lease cfg? */
 				if (c->lease_cfg != lease_cfg)
 					continue;


### PR DESCRIPTION
Quoting from https://github.com/openwrt/odhcpd/issues/321:

	[71802.880039] odhcpd[22696]: segfault at 78...

Quoting from https://forum.openwrt.org/t/odhcpd-crash-loop-when-receiving-packet/243015/69:

	[   77.761062] odhcpd[2075]: segfault at 78...

0x78 is the offset of duid_count in struct lease_cfg, so if lease_cfg is null, we'd end up reading from address 0x78 when trying to read lease_cfg->duid_count.

This should fix the issue. Thanks to @klipz in the forums for giving me SSH access to an awesome test sandbox.

Closes: https://github.com/openwrt/odhcpd/issues/321