### PR TITLE
odhcpd: simplify statefile, remove flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ and may also receive information from ubus
 | Option	| Type	|Default| Description |
 | :------------ | :---- | :----	| :---------- |
 | maindhcp	| bool	| 0	| Use odhcpd as the main DHCPv4 service |
-| leasefile	| string|	| DHCP/v6 lease/hostfile |
+| leasefile	| string|	| DHCPv4/6 lease file |
 | leasetrigger	| string|	| Lease trigger script |
-| hostsdir	| string|	| DHCP/v6 hostfile directory (one file per interface will be created) |
+| hostsdir	| string|	| DHCPv4/v6 hostfile directory (one file per interface will be created) |
 | loglevel	|integer| 6	| Syslog level priority (0-7) |
 | piofolder	|string |	| Folder to store IPv6 prefix information (to detect stale prefixes, see RFC9096, §3.5) |
 | enable_tz |bool | 1 | Toggle whether RFC4833 timezone information is sent to clients, if set in system  |

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -589,7 +589,7 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg req_msg, const uint8_t *re
 
 		lease->flags &= ~OAF_BOUND;
 
-		if (!(lease->flags & OAF_STATIC) || lease->lease_cfg->ipv4.s_addr != lease->ipv4.s_addr) {
+		if (!lease->lease_cfg || lease->lease_cfg->ipv4.s_addr != lease->ipv4.s_addr) {
 			memset(lease->hwaddr, 0, sizeof(lease->hwaddr));
 			lease->valid_until = now + 3600; /* Block address for 1h */
 		} else {
@@ -603,9 +603,9 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg req_msg, const uint8_t *re
 			return NULL;
 
 		/* Old lease, but with an address that is out-of-scope? */
-		if (lease && ((lease->ipv4.s_addr & iface->dhcpv4_own_ip.netmask) !=
-		     (iface->dhcpv4_start_ip.s_addr & iface->dhcpv4_own_ip.netmask)) &&
-		    !(lease->flags & OAF_STATIC)) {
+		if (lease && !lease->lease_cfg &&
+		    ((lease->ipv4.s_addr & iface->dhcpv4_own_ip.netmask) !=
+		     (iface->dhcpv4_start_ip.s_addr & iface->dhcpv4_own_ip.netmask))) {
 			/* Try to reassign to an address that is in-scope */
 			avl_delete(&iface->dhcpv4_leases, &lease->iface_avl);
 			lease->ipv4.s_addr = INADDR_ANY;
@@ -634,8 +634,6 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg req_msg, const uint8_t *re
 			}
 
 			if (lease_cfg) {
-				lease->flags |= OAF_STATIC;
-
 				if (lease_cfg->hostname) {
 					lease->hostname = strdup(lease_cfg->hostname);
 					lease->hostname_valid = true;
@@ -663,7 +661,7 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg req_msg, const uint8_t *re
 			break;
 		}
 
-		if ((!(lease->flags & OAF_STATIC) || !lease->hostname) && req_hostname_len > 0) {
+		if (req_hostname_len > 0 && (!lease->lease_cfg || !lease->lease_cfg->hostname)) {
 			char *new_name = realloc(lease->hostname, req_hostname_len + 1);
 			if (new_name) {
 				lease->hostname = new_name;

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -636,8 +636,10 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg req_msg, const uint8_t *re
 			if (lease_cfg) {
 				lease->flags |= OAF_STATIC;
 
-				if (lease_cfg->hostname)
+				if (lease_cfg->hostname) {
 					lease->hostname = strdup(lease_cfg->hostname);
+					lease->hostname_valid = true;
+				}
 
 				lease_cfg->dhcpv4_lease = lease;
 				lease->lease_cfg = lease_cfg;
@@ -667,11 +669,7 @@ dhcpv4_lease(struct interface *iface, enum dhcpv4_msg req_msg, const uint8_t *re
 				lease->hostname = new_name;
 				memcpy(lease->hostname, req_hostname, req_hostname_len);
 				lease->hostname[req_hostname_len] = 0;
-
-				if (odhcpd_valid_hostname(lease->hostname))
-					lease->flags &= ~OAF_BROKEN_HOSTNAME;
-				else
-					lease->flags |= OAF_BROKEN_HOSTNAME;
+				lease->hostname_valid = odhcpd_hostname_valid(lease->hostname);
 			}
 		}
 

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -820,7 +820,7 @@ struct log_ctxt {
 	int buf_idx;
 };
 
-static void dhcpv6_log_ia_addr(_o_unused struct dhcpv6_lease *lease, struct in6_addr *addr, int prefix,
+static void dhcpv6_log_ia_addr(_o_unused struct dhcpv6_lease *lease, struct in6_addr *addr, uint8_t prefix_len,
 			       _o_unused uint32_t pref_lt, _o_unused uint32_t valid_lt, void *arg)
 {
 	struct log_ctxt *ctxt = (struct log_ctxt *)arg;
@@ -828,7 +828,7 @@ static void dhcpv6_log_ia_addr(_o_unused struct dhcpv6_lease *lease, struct in6_
 
 	inet_ntop(AF_INET6, addr, addrbuf, sizeof(addrbuf));
 	ctxt->buf_idx += snprintf(ctxt->buf + ctxt->buf_idx, ctxt->buf_len - ctxt->buf_idx,
-					"%s/%d ", addrbuf, prefix);
+				  " %s/%" PRIu8, addrbuf, prefix_len);
 }
 
 static void dhcpv6_log(uint8_t msgtype, struct interface *iface, time_t now,
@@ -889,7 +889,7 @@ static void dhcpv6_log(uint8_t msgtype, struct interface *iface, time_t now,
 		odhcpd_enum_addr6(iface, a, now, dhcpv6_log_ia_addr, &ctxt);
 	}
 
-	info("DHCPV6 %s %s from %s on %s: %s %s", type, (is_pd) ? "IA_PD" : "IA_NA",
+	info("DHCPV6 %s %s from %s on %s: %s%s", type, (is_pd) ? "IA_PD" : "IA_NA",
 	     duidbuf, iface->name, status, leasebuf);
 }
 

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1226,12 +1226,9 @@ proceed:
 			ia_response_len = build_ia(buf, buflen, status, ia, a, iface,
 							hdr->msg_type == DHCPV6_MSG_REBIND ? false : true);
 
-			/* Was only a solicitation: mark binding for removal */
+			/* Was only a solicitation: mark binding for removal in 60 seconds */
 			if (assigned && hdr->msg_type == DHCPV6_MSG_SOLICIT && !rapid_commit) {
 				a->flags &= ~OAF_BOUND;
-				a->flags |= OAF_TENTATIVE;
-
-				/* Keep tentative assignment around for 60 seconds */
 				a->valid_until = now + 60;
 
 			} else if (assigned &&
@@ -1248,7 +1245,6 @@ proceed:
 					}
 				}
 				a->accept_fr_nonce = accept_reconf;
-				a->flags &= ~OAF_TENTATIVE;
 				a->flags |= OAF_BOUND;
 				apply_lease(a, true);
 			} else if (!assigned) {

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1171,8 +1171,6 @@ proceed:
 							assigned = assign_na(iface, a);
 
 						if (lease_cfg && assigned) {
-							a->flags |= OAF_STATIC;
-
 							if (lease_cfg->hostname) {
 								a->hostname = strdup(lease_cfg->hostname);
 								a->hostname_valid = true;
@@ -1240,7 +1238,7 @@ proceed:
 				   ((hdr->msg_type == DHCPV6_MSG_SOLICIT && rapid_commit) ||
 				    hdr->msg_type == DHCPV6_MSG_REQUEST ||
 				    hdr->msg_type == DHCPV6_MSG_REBIND)) {
-				if ((!(a->flags & OAF_STATIC) || !a->hostname) && hostname_len > 0) {
+				if (hostname_len > 0 && (!a->lease_cfg || !a->lease_cfg->hostname)) {
 					char *tmp = realloc(a->hostname, hostname_len + 1);
 					if (tmp) {
 						a->hostname = tmp;
@@ -1277,7 +1275,7 @@ proceed:
 			} else if ((a->flags & OAF_DHCPV6_NA) && hdr->msg_type == DHCPV6_MSG_DECLINE) {
 				a->flags &= ~OAF_BOUND;
 
-				if (!(a->flags & OAF_STATIC) || a->lease_cfg->hostid != a->assigned_host_id) {
+				if (!a->lease_cfg || a->lease_cfg->hostid != a->assigned_host_id) {
 					memset(a->duid, 0, a->duid_len);
 					a->valid_until = now + 3600; /* Block address for 1h */
 				} else

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1173,8 +1173,10 @@ proceed:
 						if (lease_cfg && assigned) {
 							a->flags |= OAF_STATIC;
 
-							if (lease_cfg->hostname)
+							if (lease_cfg->hostname) {
 								a->hostname = strdup(lease_cfg->hostname);
+								a->hostname_valid = true;
+							}
 
 							if (lease_cfg->leasetime)
 								a->leasetime = lease_cfg->leasetime;
@@ -1244,11 +1246,7 @@ proceed:
 						a->hostname = tmp;
 						memcpy(a->hostname, hostname, hostname_len);
 						a->hostname[hostname_len] = 0;
-
-						if (odhcpd_valid_hostname(a->hostname))
-							a->flags &= ~OAF_BROKEN_HOSTNAME;
-						else
-							a->flags |= OAF_BROKEN_HOSTNAME;
+						a->hostname_valid = odhcpd_hostname_valid(a->hostname);
 					}
 				}
 				a->accept_fr_nonce = accept_reconf;

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -756,14 +756,13 @@ int odhcpd_parse_addr6_prefix(const char *str, struct in6_addr *addr, uint8_t *p
 	return 0;
 }
 
-bool odhcpd_valid_hostname(const char *name)
+bool odhcpd_hostname_valid(const char *name)
 {
-#define MAX_LABEL	63
 	const char *c, *label, *label_end;
 	int label_sz = 0;
 
 	for (c = name, label_sz = 0, label = name, label_end = name + strcspn(name, ".") - 1;
-			*c && label_sz <= MAX_LABEL; c++) {
+			*c && label_sz <= DNS_MAX_LABEL_LEN; c++) {
 		if ((*c >= '0' && *c <= '9') ||
 		    (*c >= 'A' && *c <= 'Z') ||
 		    (*c >= 'a' && *c <= 'z')) {
@@ -771,6 +770,7 @@ bool odhcpd_valid_hostname(const char *name)
 			continue;
 		}
 
+		/* FIXME: underscore is not allowed in RFC 1035, RFC 1123? */
 		if ((*c == '_' || *c == '-') && c != label && c != label_end) {
 			label_sz++;
 			continue;
@@ -788,5 +788,5 @@ bool odhcpd_valid_hostname(const char *name)
 		return false;
 	}
 
-	return (label_sz && label_sz <= MAX_LABEL ? true : false);
+	return (label_sz && label_sz <= DNS_MAX_LABEL_LEN ? true : false);
 }

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -192,9 +192,8 @@ enum odhcpd_mode {
 enum odhcpd_assignment_flags {
 	OAF_TENTATIVE		= (1 << 0),
 	OAF_BOUND		= (1 << 1),
-	OAF_STATIC		= (1 << 2),
-	OAF_DHCPV6_NA		= (1 << 3),
-	OAF_DHCPV6_PD		= (1 << 4),
+	OAF_DHCPV6_NA		= (1 << 2),
+	OAF_DHCPV6_PD		= (1 << 3),
 };
 
 /* 2-byte type + 128-byte DUID, RFC8415, §11.1 */

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -190,9 +190,8 @@ enum odhcpd_mode {
 
 
 enum odhcpd_assignment_flags {
-	OAF_BOUND		= (1 << 0),
-	OAF_DHCPV6_NA		= (1 << 1),
-	OAF_DHCPV6_PD		= (1 << 2),
+	OAF_DHCPV6_NA		= (1 << 0),
+	OAF_DHCPV6_PD		= (1 << 1),
 };
 
 /* 2-byte type + 128-byte DUID, RFC8415, §11.1 */
@@ -254,7 +253,7 @@ struct dhcpv4_lease {
 	struct lease_cfg *lease_cfg;		// host lease cfg, nullable
 
 	struct in_addr ipv4;			// client IPv4 address
-	unsigned int flags;			// OAF_*
+	bool bound;				// the lease has been accepted by the client
 	time_t valid_until;			// CLOCK_MONOTONIC time, 0 = inf
 	char *hostname;				// client hostname
 	bool hostname_valid;			// is the hostname one or more valid DNS labels?
@@ -298,6 +297,7 @@ struct dhcpv6_lease {
 	uint8_t length; // length == 128 -> IA_NA, length <= 64 -> IA_PD
 
 	unsigned int flags;
+	bool bound;				// the lease has been accepted by the client
 	uint32_t leasetime;
 	char *hostname;
 	bool hostname_valid;			// is the hostname one or more valid DNS labels?

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -193,9 +193,8 @@ enum odhcpd_assignment_flags {
 	OAF_TENTATIVE		= (1 << 0),
 	OAF_BOUND		= (1 << 1),
 	OAF_STATIC		= (1 << 2),
-	OAF_BROKEN_HOSTNAME	= (1 << 3),
-	OAF_DHCPV6_NA		= (1 << 4),
-	OAF_DHCPV6_PD		= (1 << 5),
+	OAF_DHCPV6_NA		= (1 << 3),
+	OAF_DHCPV6_PD		= (1 << 4),
 };
 
 /* 2-byte type + 128-byte DUID, RFC8415, §11.1 */
@@ -260,6 +259,7 @@ struct dhcpv4_lease {
 	unsigned int flags;			// OAF_*
 	time_t valid_until;			// CLOCK_MONOTONIC time, 0 = inf
 	char *hostname;				// client hostname
+	bool hostname_valid;			// is the hostname one or more valid DNS labels?
 	size_t hwaddr_len;			// hwaddr length
 	uint8_t hwaddr[ETH_ALEN];		// hwaddr (only MAC supported)
 
@@ -302,6 +302,7 @@ struct dhcpv6_lease {
 	unsigned int flags;
 	uint32_t leasetime;
 	char *hostname;
+	bool hostname_valid;			// is the hostname one or more valid DNS labels?
 
 	uint32_t iaid;
 	uint16_t duid_len;
@@ -565,7 +566,7 @@ typedef void (*odhcpd_enum_addr6_cb_t)(struct dhcpv6_lease *lease,
 void odhcpd_enum_addr6(struct interface *iface, struct dhcpv6_lease *lease,
 		       time_t now, odhcpd_enum_addr6_cb_t func, void *arg);
 int odhcpd_parse_addr6_prefix(const char *str, struct in6_addr *addr, uint8_t *prefix);
-bool odhcpd_valid_hostname(const char *name);
+bool odhcpd_hostname_valid(const char *name);
 
 int config_parse_interface(void *data, size_t len, const char *iname, bool overwrite);
 struct lease_cfg *config_find_lease_cfg_by_duid_and_iaid(const uint8_t *duid,

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -559,7 +559,7 @@ int odhcpd_bmemcmp(const void *av, const void *bv, size_t bits);
 void odhcpd_bmemcpy(void *av, const void *bv, size_t bits);
 
 typedef void (*odhcpd_enum_addr6_cb_t)(struct dhcpv6_lease *lease,
-				       struct in6_addr *addr, int prefix,
+				       struct in6_addr *addr, uint8_t prefix_len,
 				       uint32_t pref, uint32_t valid,
 				       void *arg);
 void odhcpd_enum_addr6(struct interface *iface, struct dhcpv6_lease *lease,

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -190,10 +190,9 @@ enum odhcpd_mode {
 
 
 enum odhcpd_assignment_flags {
-	OAF_TENTATIVE		= (1 << 0),
-	OAF_BOUND		= (1 << 1),
-	OAF_DHCPV6_NA		= (1 << 2),
-	OAF_DHCPV6_PD		= (1 << 3),
+	OAF_BOUND		= (1 << 0),
+	OAF_DHCPV6_NA		= (1 << 1),
+	OAF_DHCPV6_PD		= (1 << 2),
 };
 
 /* 2-byte type + 128-byte DUID, RFC8415, §11.1 */

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -122,7 +122,7 @@ static void statefiles_write_hosts(time_t now)
 			struct dhcpv6_lease *lease;
 
 			list_for_each_entry(lease, &ctxt.iface->ia_assignments, head) {
-				if (!(lease->flags & OAF_BOUND))
+				if (!lease->bound)
 					continue;
 
 				if (!INFINITE_VALID(lease->valid_until) && lease->valid_until <= now)
@@ -137,7 +137,7 @@ static void statefiles_write_hosts(time_t now)
 			struct dhcpv4_lease *lease;
 
 			avl_for_each_element(&ctxt.iface->dhcpv4_leases, lease, iface_avl) {
-				if (!(lease->flags & OAF_BOUND))
+				if (!lease->bound)
 					continue;
 
 				if (!INFINITE_VALID(lease->valid_until) && lease->valid_until <= now)
@@ -273,7 +273,7 @@ static bool statefiles_write_state(time_t now)
 			struct dhcpv6_lease *lease;
 
 			list_for_each_entry(lease, &ctxt.iface->ia_assignments, head) {
-				if (!(lease->flags & OAF_BOUND))
+				if (!lease->bound)
 					continue;
 
 				if (!INFINITE_VALID(lease->valid_until) && lease->valid_until <= now)
@@ -287,7 +287,7 @@ static bool statefiles_write_state(time_t now)
 			struct dhcpv4_lease *lease;
 
 			avl_for_each_element(&ctxt.iface->dhcpv4_leases, lease, iface_avl) {
-				if (!(lease->flags & OAF_BOUND))
+				if (!lease->bound)
 					continue;
 
 				if (!INFINITE_VALID(lease->valid_until) && lease->valid_until <= now)

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -59,7 +59,7 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _o_unused struct ubus_
 			blobmsg_add_u8(&b, "accept-reconf", c->accept_fr_nonce);
 
 			m = blobmsg_open_array(&b, "flags");
-			if (c->flags & OAF_BOUND)
+			if (c->bound)
 				blobmsg_add_string(&b, NULL, "bound");
 
 			if (c->lease_cfg)
@@ -151,7 +151,7 @@ static int handle_dhcpv6_leases(_o_unused struct ubus_context *ctx, _o_unused st
 				blobmsg_add_u16(&b, "assigned", a->assigned_subnet_id);
 
 			m = blobmsg_open_array(&b, "flags");
-			if (a->flags & OAF_BOUND)
+			if (a->bound)
 				blobmsg_add_string(&b, NULL, "bound");
 
 			if (a->lease_cfg)

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -90,7 +90,7 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _o_unused struct ubus_
 }
 #endif /* DHCPV4_SUPPORT */
 
-static void dhcpv6_blobmsg_ia_addr(_o_unused struct dhcpv6_lease *lease, struct in6_addr *addr, int prefix,
+static void dhcpv6_blobmsg_ia_addr(_o_unused struct dhcpv6_lease *lease, struct in6_addr *addr, uint8_t prefix_len,
 				   uint32_t pref_lt, uint32_t valid_lt, _o_unused void *arg)
 {
 	void *a	= blobmsg_open_table(&b, NULL);
@@ -103,8 +103,8 @@ static void dhcpv6_blobmsg_ia_addr(_o_unused struct dhcpv6_lease *lease, struct 
 	blobmsg_add_u32(&b, "valid-lifetime",
 			valid_lt == UINT32_MAX ? (uint32_t)-1 : valid_lt);
 
-	if (prefix != 128)
-		blobmsg_add_u32(&b, "prefix-length", prefix);
+	if (prefix_len != 128)
+		blobmsg_add_u32(&b, "prefix-length", prefix_len);
 
 	blobmsg_close_table(&b, a);
 }

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -62,7 +62,7 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _o_unused struct ubus_
 			if (c->flags & OAF_BOUND)
 				blobmsg_add_string(&b, NULL, "bound");
 
-			if (c->flags & OAF_STATIC)
+			if (c->lease_cfg)
 				blobmsg_add_string(&b, NULL, "static");
 
 			if (!c->hostname_valid)
@@ -154,7 +154,7 @@ static int handle_dhcpv6_leases(_o_unused struct ubus_context *ctx, _o_unused st
 			if (a->flags & OAF_BOUND)
 				blobmsg_add_string(&b, NULL, "bound");
 
-			if (a->flags & OAF_STATIC)
+			if (a->lease_cfg)
 				blobmsg_add_string(&b, NULL, "static");
 			blobmsg_close_array(&b, m);
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -65,7 +65,7 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _o_unused struct ubus_
 			if (c->flags & OAF_STATIC)
 				blobmsg_add_string(&b, NULL, "static");
 
-			if (c->flags & OAF_BROKEN_HOSTNAME)
+			if (!c->hostname_valid)
 				blobmsg_add_string(&b, NULL, "broken-hostname");
 			blobmsg_close_array(&b, m);
 


### PR DESCRIPTION
First, the statefile is simplified by removing the hosts entries from the file. Hosts are already handled by the separate `hostsdir` directive, which is enabled by default.

Second, go through the various `OAF_` flags and remove a bunch of flags which are either redundant, or which can be replaced with a simple `bool`.