### PR TITLE
build: disable static libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,8 @@ jobs:
           cmake \
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
-            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_STATIC_LIBS=OFF \
             -DDISABLE_EXTRA_LIBS=ON \
             -DBUILD_TESTING=OFF \
             --install-prefix ${GITHUB_WORKSPACE}/build \
@@ -161,6 +162,7 @@ jobs:
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DBUILD_LUA=OFF \
+            -DBUILD_STATIC=OFF \
             -DBUILD_EXAMPLES=OFF \
             --install-prefix ${GITHUB_WORKSPACE}/build \
             -B . -S .
@@ -174,6 +176,7 @@ jobs:
             -DCMAKE_C_COMPILER=${{ matrix.gcc }} \
             -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/build \
             -DBUILD_LUA=OFF \
+            -DBUILD_STATIC=OFF \
             --install-prefix ${GITHUB_WORKSPACE}/build \
             -B . -S .
           make

--- a/scripts/devel-build.sh
+++ b/scripts/devel-build.sh
@@ -37,7 +37,8 @@ cmake							\
 	-S .						\
 	-B .						\
 	-DCMAKE_PREFIX_PATH="${BUILDDIR}"		\
-	-DBUILD_SHARED_LIBS=OFF				\
+	-DBUILD_SHARED_LIBS=ON				\
+	-DBUILD_STATIC_LIBS=OFF				\
 	-DDISABLE_EXTRA_LIBS=ON				\
 	-DBUILD_TESTING=OFF				\
 	--install-prefix "${BUILDDIR}"
@@ -73,6 +74,7 @@ cmake							\
 	-B .						\
 	-DCMAKE_PREFIX_PATH="${BUILDDIR}"		\
 	-DBUILD_LUA=OFF					\
+	-DBUILD_STATIC=OFF				\
 	-DBUILD_EXAMPLES=OFF				\
 	--install-prefix "${BUILDDIR}"
 make
@@ -85,6 +87,7 @@ cmake							\
 	-B .						\
 	-DCMAKE_PREFIX_PATH="${BUILDDIR}"		\
 	-DBUILD_LUA=OFF					\
+	-DBUILD_STATIC=OFF				\
 	--install-prefix "${BUILDDIR}"
 make
 make install


### PR DESCRIPTION
Allows linking against shared json-c, which reduces the binary size and matches the OpenWrt package binary.

CC @Alphix @systemcrash 