### PR TITLE
dhcpv6-ia: fix crash in dhcpv6_free_lease()

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -60,6 +60,9 @@ dhcpv6_alloc_lease(size_t extra_len)
 
 void dhcpv6_free_lease(struct dhcpv6_lease *a)
 {
+	if (!a)
+		return;
+
 	list_del(&a->head);
 	list_del(&a->lease_cfg_list);
 


### PR DESCRIPTION
Note that dhcpv6_free_lease() can be called with a NULL argument e.g. from dhcpv6_ia_handle_IAs() when iface->no_dynamic_dhcp is set and a client without a static lease cfg tries to get a dynamic lease.

Closes: #321