### PR TITLE
router: remove duplicated PIOs

### DIFF
--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -346,10 +346,13 @@ struct dnr_options {
 
 // RA PIO - RFC9096
 struct ra_pio {
-	struct in6_addr prefix;
-	uint8_t length;
+	struct {
+		struct in6_addr prefix;
+		uint8_t length;
+	};
 	time_t lifetime;
 };
+#define ra_pio_cmp_len offsetof(struct ra_pio, lifetime)
 
 
 struct interface {

--- a/src/router.c
+++ b/src/router.c
@@ -544,9 +544,7 @@ static void router_clear_duplicated_ra_pio(struct interface *iface)
 				     inet_ntop(AF_INET6, &pio_a->prefix, ipv6_str, sizeof(ipv6_str)),
 				     pio_a->length);
 
-				if (j + 1 < iface->pio_cnt)
-					iface->pios[j] = iface->pios[iface->pio_cnt - 1];
-
+				iface->pios[j] = iface->pios[iface->pio_cnt - 1];
 				iface->pio_cnt--;
 			} else {
 				j++;
@@ -577,9 +575,7 @@ static void router_clear_expired_ra_pio(time_t now,
 			     inet_ntop(AF_INET6, &cur_pio->prefix, ipv6_str, sizeof(ipv6_str)),
 			     cur_pio->length);
 
-			if (i + 1 < iface->pio_cnt)
-				iface->pios[i] = iface->pios[iface->pio_cnt - 1];
-
+			iface->pios[i] = iface->pios[iface->pio_cnt - 1];
 			iface->pio_cnt--;
 		} else {
 			i++;

--- a/src/router.c
+++ b/src/router.c
@@ -538,8 +538,7 @@ static void router_clear_duplicated_ra_pio(struct interface *iface)
 		while (j < iface->pio_cnt) {
 			struct ra_pio *pio_b = &iface->pios[j];
 
-			if (pio_a->length == pio_b->length &&
-			    !memcmp(&pio_a->prefix, &pio_b->prefix, sizeof(struct in6_addr))) {
+			if (!memcmp(pio_a, pio_b, ra_pio_cmp_len)) {
 				warn("rfc9096: %s: clear duplicated %s/%u",
 				     iface->ifname,
 				     inet_ntop(AF_INET6, &pio_a->prefix, ipv6_str, sizeof(ipv6_str)),

--- a/src/router.c
+++ b/src/router.c
@@ -526,7 +526,7 @@ static void router_add_ra_pio(struct interface *iface,
 	     pio->length);
 }
 
-static void router_clear_ra_pio(time_t now,
+static void router_clear_expired_ra_pio(time_t now,
 	struct interface *iface)
 {
 	size_t i = 0, pio_cnt = iface->pio_cnt;
@@ -536,7 +536,7 @@ static void router_clear_ra_pio(time_t now,
 		struct ra_pio *cur_pio = &iface->pios[i];
 
 		if (ra_pio_expired(cur_pio, now)) {
-			info("rfc9096: %s: clear %s/%u",
+			info("rfc9096: %s: clear expired %s/%u",
 			     iface->ifname,
 			     inet_ntop(AF_INET6, &cur_pio->prefix, ipv6_str, sizeof(ipv6_str)),
 			     cur_pio->length);
@@ -611,7 +611,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	bool valid_prefix = false;
 	char buf[INET6_ADDRSTRLEN];
 
-	router_clear_ra_pio(now, iface);
+	router_clear_expired_ra_pio(now, iface);
 
 	memset(&adv, 0, sizeof(adv));
 	adv.h.nd_ra_type = ND_ROUTER_ADVERT;


### PR DESCRIPTION
There can be duplicated PIOs if the user changed the assigned prefix length in the configuration.

~~Draft until https://github.com/openwrt/odhcpd/pull/330 is merged.~~