### PR TITLE
dhcpv4: don't send zero IPv6-only preferred option

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1306,7 +1306,8 @@ void dhcpv4_handle_msg(void *src_addr, void *data, size_t len,
 			break;
 
 		case DHCPV4_OPT_IPV6_ONLY_PREFERRED:
-			iov[IOV_IPV6_ONLY_PREF].iov_len = sizeof(reply_ipv6_only);
+			if (iface->dhcpv4_v6only_wait)
+				iov[IOV_IPV6_ONLY_PREF].iov_len = sizeof(reply_ipv6_only);
 			break;
 
 		case DHCPV4_OPT_CAPTIVE_PORTAL:


### PR DESCRIPTION
As noted in https://github.com/openwrt/openwrt/issues/21048, if the ipv6_only_preferred option isn't set (or is set to zero), odhcpd will still include the IPv6-Only Preferred option (with a zero value) in DHCPv4 replies, while it should not return the option at all.

Closes: https://github.com/openwrt/openwrt/issues/21048