### PR TITLE
odhcpd: option fixups

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1119,8 +1119,8 @@ void dhcpv4_handle_msg(void *src_addr, void *data, size_t len,
 				reply_dnsserver.len = iface->dns_addrs4_cnt * sizeof(*iface->dns_addrs4);
 				iov[IOV_DNSSERVER_ADDRS].iov_base = iface->dns_addrs4;
 			} else {
-				reply_dnsserver.len = sizeof(iface->dhcpv4_own_ip);
-				iov[IOV_DNSSERVER_ADDRS].iov_base = &iface->dhcpv4_own_ip;
+				reply_dnsserver.len = sizeof(iface->dhcpv4_own_ip.addr.in);
+				iov[IOV_DNSSERVER_ADDRS].iov_base = &iface->dhcpv4_own_ip.addr.in;
 			}
 			iov[IOV_DNSSERVER_ADDRS].iov_len = reply_dnsserver.len;
 			break;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -391,9 +391,7 @@ struct interface {
 	struct avl_tree dhcpv4_leases;
 	struct list_head dhcpv4_fr_ips;
 
-	// RFC8910
-	char *captive_portal_uri;
-	size_t captive_portal_uri_len;
+	/* NOTE: everything from this point is zeroed on odhcpd_reload() */
 
 	// Services
 	enum odhcpd_mode ra;
@@ -494,6 +492,10 @@ struct interface {
 	struct ra_pio *pios;
 	size_t pio_cnt;
 	bool pio_update;
+
+	// RFC8910
+	char *captive_portal_uri;
+	size_t captive_portal_uri_len;
 };
 
 extern struct avl_tree interfaces;


### PR DESCRIPTION
Two small fixes for option handling.

The first one is for the DHCPv4 server when no DNS server is set.

The second one fixes the captive_portal_uri on reset.