### PR TITLE
[25.12] backport fixes from master

### DIFF
--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -346,13 +346,10 @@ struct dnr_options {
 
 // RA PIO - RFC9096
 struct ra_pio {
-	struct {
-		struct in6_addr prefix;
-		uint8_t length;
-	};
+	struct in6_addr prefix;
+	uint8_t length;
 	time_t lifetime;
 };
-#define ra_pio_cmp_len offsetof(struct ra_pio, lifetime)
 
 
 struct interface {

--- a/src/router.c
+++ b/src/router.c
@@ -539,7 +539,8 @@ static void router_clear_duplicated_ra_pio(struct interface *iface)
 		while (j < iface->pio_cnt) {
 			struct ra_pio *pio_b = &iface->pios[j];
 
-			if (!memcmp(pio_a, pio_b, ra_pio_cmp_len)) {
+			if (pio_a->length == pio_b->length &&
+			    !memcmp(&pio_a->prefix, &pio_b->prefix, sizeof(struct in6_addr))) {
 				warn("rfc9096: %s: clear duplicated %s/%u",
 				     iface->ifname,
 				     inet_ntop(AF_INET6, &pio_a->prefix, ipv6_str, sizeof(ipv6_str)),

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -488,7 +488,7 @@ static void statefiles_write_state6(struct write_ctxt *ctxt, struct dhcpv6_lease
 		fprintf(ctxt->fp,
 			"# %s %s %x %s%s %" PRId64 " %" PRIx64 " %" PRIu8,
 			ctxt->iface->ifname, duidbuf, ntohl(lease->iaid),
-			lease->hostname_valid ? "" : "broken\\x20",
+			lease->hostname && !lease->hostname_valid ? "broken\\x20": "",
 			lease->hostname ? lease->hostname : "-",
 			(lease->valid_until > ctxt->now ?
 			 (int64_t)(lease->valid_until - ctxt->now + ctxt->wall_time) :
@@ -524,7 +524,7 @@ static void statefiles_write_state4(struct write_ctxt *ctxt, struct dhcpv4_lease
 		"# %s %s ipv4 %s%s %" PRId64 " %x 32 %s/32\n",
 		ctxt->iface->ifname,
 		ether_ntoa((struct ether_addr *)lease->hwaddr),
-		lease->hostname_valid ? "" : "broken\\x20",
+		lease->hostname && !lease->hostname_valid ? "broken\\x20" : "",
 		lease->hostname ? lease->hostname : "-",
 		(lease->valid_until > ctxt->now ?
 		 (int64_t)(lease->valid_until - ctxt->now + ctxt->wall_time) :


### PR DESCRIPTION
7ebd96083971 Revert "router: optimize duplicated PIO comparison"
90ae6fc6e478 statefiles: don't consider no hostname as broken