### PR TITLE
[25.12] backport fixes/updates from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ and may also receive information from ubus
 | dhcpv6_na		|bool	| 1	| DHCPv6 stateful addressing hands out IA_NA - Internet Address - Network Address |
 | dhcpv6_pd		|bool	| 1	| DHCPv6 stateful addressing hands out IA_PD - Internet Address - Prefix Delegation (PD) |
 | dhcpv6_pd_preferred   |bool | 0 | Set the DHCPv6-PD Preferred (P) flag in outgoing ICMPv6 RA message PIOs (RFC9762); requires `dhcpv6` and `dhcpv6_pd`. |
-| dhcpv6_pd_min_len	|integer| -	| Minimum prefix length to delegate with IA_PD (value is adjusted if needed to be greater than the interface prefix length).  Range [1,62] |
+| dhcpv6_pd_min_len	|integer| -	| Minimum prefix length to delegate with IA_PD (value is adjusted if needed to be greater than the interface prefix length).  Range [1,64] |
 | router		|list	|`<local address>`| IPv4 addresses of routers on a given subnet (provided via DHCPv4, should be in order of preference) |
 | dns			|list	|`<local address>`| DNS servers to announce, accepts IPv4 and IPv6 |
 | dnr			|list	|disabled| Encrypted DNS servers to announce, `<priority> <domain name> [<comma separated IP addresses> <SvcParams (key=value)>...]` |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ and may also receive information from ubus
 | dhcpv6_na		|bool	| 1	| DHCPv6 stateful addressing hands out IA_NA - Internet Address - Network Address |
 | dhcpv6_pd		|bool	| 1	| DHCPv6 stateful addressing hands out IA_PD - Internet Address - Prefix Delegation (PD) |
 | dhcpv6_pd_preferred   |bool | 0 | Set the DHCPv6-PD Preferred (P) flag in outgoing ICMPv6 RA message PIOs (RFC9762); requires `dhcpv6` and `dhcpv6_pd`. |
-| dhcpv6_pd_min_len	|integer| -	| Minimum prefix length to delegate with IA_PD (value is adjusted if needed to be greater than the interface prefix length).  Range [1,64] |
+| dhcpv6_pd_min_len	|integer| 62	| Minimum prefix length to delegate with IA_PD (adjusted, if necessary, to be longer than the interface prefix length).  Range [1,64] |
 | router		|list	|`<local address>`| IPv4 addresses of routers on a given subnet (provided via DHCPv4, should be in order of preference) |
 | dns			|list	|`<local address>`| DNS servers to announce, accepts IPv4 and IPv6 |
 | dnr			|list	|disabled| Encrypted DNS servers to announce, `<priority> <domain name> [<comma separated IP addresses> <SvcParams (key=value)>...]` |

--- a/src/config.c
+++ b/src/config.c
@@ -69,7 +69,8 @@ struct sys_conf sys_conf = {
 #define HOSTID_LEN_MAX	64
 #define HOSTID_LEN_DEFAULT HOSTID_LEN_MIN
 
-#define PD_MIN_LEN_MAX	64
+#define PD_MIN_LEN_MAX		64
+#define PD_MIN_LEN_DEFAULT	62
 
 #define OAF_DHCPV6	(OAF_DHCPV6_NA | OAF_DHCPV6_PD)
 
@@ -324,7 +325,7 @@ static void set_interface_defaults(struct interface *iface)
 	iface->dhcpv6_assignall = true;
 	iface->dhcpv6_pd = true;
 	iface->dhcpv6_pd_preferred = false;
-	iface->dhcpv6_pd_min_len = 0;
+	iface->dhcpv6_pd_min_len = PD_MIN_LEN_DEFAULT;
 	iface->dhcpv6_na = true;
 	iface->dhcpv6_hostid_len = HOSTID_LEN_DEFAULT;
 	iface->dns_service = true;

--- a/src/config.c
+++ b/src/config.c
@@ -69,7 +69,7 @@ struct sys_conf sys_conf = {
 #define HOSTID_LEN_MAX	64
 #define HOSTID_LEN_DEFAULT HOSTID_LEN_MIN
 
-#define PD_MIN_LEN_MAX (64-2) // must delegate at least 2 bits of prefix
+#define PD_MIN_LEN_MAX	64
 
 #define OAF_DHCPV6	(OAF_DHCPV6_NA | OAF_DHCPV6_PD)
 
@@ -1456,12 +1456,14 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_DHCPV6_PD_MIN_LEN])) {
 		uint32_t pd_min_len = blobmsg_get_u32(c);
-		if (pd_min_len > PD_MIN_LEN_MAX)
-			iface->dhcpv6_pd_min_len = PD_MIN_LEN_MAX;
-		iface->dhcpv6_pd_min_len = pd_min_len;
-		if (pd_min_len > PD_MIN_LEN_MAX)
+
+		if (pd_min_len > PD_MIN_LEN_MAX) {
+			pd_min_len = PD_MIN_LEN_MAX;
 			warn("Clamped invalid %s value configured for interface '%s' to %d",
-			     iface_attrs[IFACE_ATTR_DHCPV6_PD_MIN_LEN].name, iface->name, iface->dhcpv6_pd_min_len);
+			     iface_attrs[IFACE_ATTR_DHCPV6_PD_MIN_LEN].name, iface->name, pd_min_len);
+		}
+
+		iface->dhcpv6_pd_min_len = pd_min_len;
 	}
 
 	if ((c = tb[IFACE_ATTR_DHCPV6_NA]))


### PR DESCRIPTION
- cb1b8770b782 config: add default value for dhcpv6_pd_min_len
- 20eb94d02dfe config: allow minimum PD len up to 64