### PR TITLE
[25.12] backport fixes/updates from master

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -72,8 +72,6 @@ struct sys_conf sys_conf = {
 #define PD_MIN_LEN_MAX		64
 #define PD_MIN_LEN_DEFAULT	62
 
-#define OAF_DHCPV6	(OAF_DHCPV6_NA | OAF_DHCPV6_PD)
-
 enum {
 	IPV6_PXE_URL,
 	IPV6_PXE_ARCH,

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -19,7 +19,6 @@
 #include <unistd.h>
 #include <stddef.h>
 #include <stdlib.h>
-#include <resolv.h>
 #include <limits.h>
 #include <alloca.h>
 #include <net/if.h>
@@ -1211,21 +1210,6 @@ void dhcpv4_handle_msg(void *src_addr, void *data, size_t len,
 				iov[IOV_SRCH_DOMAIN].iov_len = sizeof(reply_srch_domain);
 				iov[IOV_SRCH_DOMAIN_NAME].iov_base = iface->dns_search;
 				iov[IOV_SRCH_DOMAIN_NAME].iov_len = iface->dns_search_len;
-			} else if (!res_init() && _res.dnsrch[0] && _res.dnsrch[0][0]) {
-				int dds_len;
-
-				if (!iov[IOV_SRCH_DOMAIN_NAME].iov_base)
-					iov[IOV_SRCH_DOMAIN_NAME].iov_base = alloca(DNS_MAX_NAME_LEN);
-
-				dds_len = dn_comp(_res.dnsrch[0],
-					      iov[IOV_SRCH_DOMAIN_NAME].iov_base,
-					      DNS_MAX_NAME_LEN, NULL, NULL);
-				if (dds_len < 0)
-					break;
-
-				reply_srch_domain.len = dds_len;
-				iov[IOV_SRCH_DOMAIN].iov_len = sizeof(reply_srch_domain);
-				iov[IOV_SRCH_DOMAIN_NAME].iov_len = dds_len;
 			}
 			break;
 

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -215,10 +215,14 @@ static int send_reconf(struct dhcpv6_lease *assign)
 
 	memcpy(clientid.data, assign->duid, assign->duid_len);
 
+	size_t serverid_len, clientid_len;
+	serverid_len = sizeof(serverid.code) + sizeof(serverid.len) + ntohs(serverid.len);
+	clientid_len = sizeof(clientid.code) + sizeof(clientid.len) + ntohs(clientid.len);
+
 	struct iovec iov[IOV_TOTAL] = {
 		[IOV_HDR] = { &hdr, sizeof(hdr) },
-		[IOV_SERVERID] = { &serverid, sizeof(serverid) },
-		[IOV_CLIENTID] = { &clientid, sizeof(clientid) },
+		[IOV_SERVERID] = { &serverid, serverid_len },
+		[IOV_CLIENTID] = { &clientid, clientid_len },
 		[IOV_MESSAGE] = { &message, sizeof(message) },
 		[IOV_AUTH] = { &auth, sizeof(auth) },
 	};

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -16,8 +16,6 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stddef.h>
-#include <resolv.h>
-#include <sys/timerfd.h>
 #include <arpa/inet.h>
 
 #include <libubox/utils.h>
@@ -615,23 +613,10 @@ static void handle_client_request(void *addr, void *data, size_t len,
 	}
 
 	/* DNS Search options */
-	uint8_t dns_search_buf[DNS_MAX_NAME_LEN];
-	uint8_t *dns_search = iface->dns_search;
-	size_t dns_search_len = iface->dns_search_len;
-
-	if (!dns_search && !res_init() && _res.dnsrch[0] && _res.dnsrch[0][0]) {
-		int ds_len = dn_comp(_res.dnsrch[0], dns_search_buf,
-				sizeof(dns_search_buf), NULL, NULL);
-		if (ds_len > 0) {
-			dns_search = dns_search_buf;
-			dns_search_len = ds_len;
-		}
-	}
-
 	struct {
 		uint16_t type;
 		uint16_t len;
-	} dns_search_hdr = { htons(DHCPV6_OPT_DNS_DOMAIN), htons(dns_search_len) };
+	} dns_search_hdr = { htons(DHCPV6_OPT_DNS_DOMAIN), htons(iface->dns_search_len) };
 
 
 	struct _o_packed dhcpv4o6_server {
@@ -650,8 +635,8 @@ static void handle_client_request(void *addr, void *data, size_t len,
 		[IOV_RAPID_COMMIT] = {&rapid_commit, 0},
 		[IOV_DNS] = { &dns_hdr, (dns_addrs6_cnt) ? sizeof(dns_hdr) : 0},
 		[IOV_DNS_ADDR] = { dns_addrs6, dns_addrs6_cnt * sizeof(*dns_addrs6) },
-		[IOV_SEARCH] = { &dns_search_hdr, (dns_search_len) ? sizeof(dns_search_hdr) : 0 },
-		[IOV_SEARCH_DOMAIN] = { dns_search, dns_search_len },
+		[IOV_SEARCH] = { &dns_search_hdr, iface->dns_search_len ? sizeof(dns_search_hdr) : 0 },
+		[IOV_SEARCH_DOMAIN] = { iface->dns_search, iface->dns_search_len },
 		[IOV_PDBUF] = {pdbuf, 0},
 		[IOV_DHCPV6_RAW] = {iface->dhcpv6_raw, iface->dhcpv6_raw_len},
 		[IOV_NTP] = {&ntp, (ntp_cnt) ? sizeof(ntp) : 0},

--- a/src/dhcpv6.h
+++ b/src/dhcpv6.h
@@ -87,11 +87,6 @@
 #define DHCPV6_STATUS_USEMULTICAST 5
 #define DHCPV6_STATUS_NOPREFIXAVAIL 6
 
-// I just remembered I have an old one lying around...
-#define DHCPV6_ENT_NO 30462
-#define DHCPV6_ENT_TYPE 1
-
-
 #define DHCPV6_HOP_COUNT_LIMIT 32
 
 #define DHCPV6_REC_TIMEOUT	2000 /* msec */

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -16,7 +16,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <resolv.h>
 #include <getopt.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/src/router.c
+++ b/src/router.c
@@ -1017,16 +1017,16 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 		uint32_t valid_lt;
 
 		if (addr->dprefix_len >= 64 || addr->dprefix_len == 0 || addr->valid_lt <= (uint32_t)now) {
-			info("Address %s (dprefix %d, valid-lifetime %u) not suitable as RA route on %s",
-			     inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
-			     addr->dprefix_len, addr->valid_lt, iface->name);
+			debug("Address %s (dprefix %d, valid-lifetime %u) not suitable as RA route on %s",
+			      inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
+			      addr->dprefix_len, addr->valid_lt, iface->name);
 			continue;
 		}
 
 		if (ADDR_MATCH_PIO_FILTER(addr, iface)) {
-			info("Address %s filtered out as RA route on %s",
-			     inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
-			     iface->name);
+			debug("Address %s filtered out as RA route on %s",
+			      inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
+			      iface->name);
 			continue;
 		}
 

--- a/src/router.c
+++ b/src/router.c
@@ -1203,7 +1203,7 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 	// MTU option
 	struct nd_opt_mtu *mtu_opt = NULL;
 	uint32_t ingress_mtu_val = 0;
-	/* PIO L/A flag and RA M/O Flags */
+	/* PIO L/A/R/P flag and RA M/O Flags */
 	uint8_t ra_flags;
 	size_t pio_count = 0;
 	struct fwd_pio_flags {
@@ -1296,6 +1296,11 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 			 */
 			if (!c->ra_slaac)
 				*pio_flags[i].ptr &= ~ND_OPT_PI_FLAG_AUTO;/* ensure A flag cleared */
+
+			/* we have no opinion on the R flag - it can be forwarded */
+
+			if (c->dhcpv6 == MODE_DISABLED || !c->dhcpv6_pd || !c->dhcpv6_pd_preferred)
+				*pio_flags[i].ptr &= ~ND_OPT_PI_FLAG_PD_PREFERRED;/* ensure P flag (DHCPv6-PD) cleared */
 		}
 
 		/* Apply per-interface modifications of upstream RA state */


### PR DESCRIPTION
- dhcpv6-ia: reconfigure message length bug fix
- all: remove dead code
- odhcpd: remove fallback DNS search domain
- router: remove some log spam in send_router_advert()
- router: improve send_router_advert()
- router: Modify relayed RA PIO P flag according to interface policy
- router: Modify relayed RA PIO A flags according to interface policy

Basically syncs master and 25.12 since there aren't big changes anyway...