### PR TITLE
[WIP] Persist leases across reboot/restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ and may also receive information from ubus
 | Option	| Type	|Default| Description |
 | :------------ | :---- | :----	| :---------- |
 | maindhcp	| bool	| 0	| Use odhcpd as the main DHCPv4 service |
-| leasefile	| string|	| DHCPv4/6 lease file |
-| leasetrigger	| string|	| Lease trigger script |
+| leasefile	| string|	| DHCPv4/6 lease file (legacy) |
+| leasetrigger	| string|	| Lease trigger script (legacy) |
+| statedir	| string|	| DHCPv4/v6 state directory (for persisting information such as active leases across reboots/restarts) |
 | hostsdir	| string|	| DHCPv4/v6 hostfile directory (one file per interface will be created) |
-| loglevel	|integer| 6	| Syslog level priority (0-7) |
 | piodir	|string |	| Directory to store IPv6 prefix information (to detect stale prefixes, see RFC9096, §3.5) |
+| loglevel	|integer| 6	| Syslog level priority (0-7) |
 | enable_tz |bool | 1 | Toggle whether RFC4833 timezone information is sent to clients, if set in system  |
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -44,6 +44,8 @@ struct config config = {
 #endif /* WITH_UBUS */
 	.dhcp_leasefile = NULL,
 	.dhcp_leasefiledir_fd = -1,
+	.statedir = NULL,
+	.statedir_fd = -1,
 	.dhcp_hostsdir = NULL,
 	.dhcp_hostsdir_fd = -1,
 	.ra_piodir = NULL,
@@ -220,6 +222,7 @@ enum {
 	ODHCPD_ATTR_LEASEFILE,
 	ODHCPD_ATTR_LEASETRIGGER,
 	ODHCPD_ATTR_LOGLEVEL,
+	ODHCPD_ATTR_STATEDIR,
 	ODHCPD_ATTR_HOSTSDIR,
 	ODHCPD_ATTR_PIODIR,
 	ODHCPD_ATTR_ENABLE_TZ,
@@ -231,6 +234,7 @@ static const struct blobmsg_policy odhcpd_attrs[ODHCPD_ATTR_MAX] = {
 	[ODHCPD_ATTR_LEASEFILE] = { .name = "leasefile", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_LEASETRIGGER] = { .name = "leasetrigger", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_LOGLEVEL] = { .name = "loglevel", .type = BLOBMSG_TYPE_INT32 },
+	[ODHCPD_ATTR_STATEDIR] = { .name = "statedir", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_HOSTSDIR] = { .name = "hostsdir", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_PIODIR] = { .name = "piodir", .type = BLOBMSG_TYPE_STRING },
 	[ODHCPD_ATTR_ENABLE_TZ] = { .name = "enable_tz", .type = BLOBMSG_TYPE_BOOL },
@@ -463,6 +467,11 @@ static void set_config(struct uci_section *s)
 		config.dhcp_leasefile = strdup(blobmsg_get_string(c));
 	}
 
+	if ((c = tb[ODHCPD_ATTR_STATEDIR])) {
+		free(config.statedir);
+		config.statedir = strdup(blobmsg_get_string(c));
+	}
+
 	if ((c = tb[ODHCPD_ATTR_HOSTSDIR])) {
 		free(config.dhcp_hostsdir);
 		config.dhcp_hostsdir = strdup(blobmsg_get_string(c));
@@ -501,6 +510,7 @@ static void set_config(struct uci_section *s)
 	} else {
 		statefiles_setup_dirfd(NULL, &config.dhcp_leasefiledir_fd);
 	}
+	statefiles_setup_dirfd(config.statedir, &config.statedir_fd);
 	statefiles_setup_dirfd(config.dhcp_hostsdir, &config.dhcp_hostsdir_fd);
 	statefiles_setup_dirfd(config.ra_piodir, &config.ra_piodir_fd);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -1766,6 +1766,7 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	}
 
 	statefiles_read_prefix_information(iface);
+	statefiles_read(iface);
 
 	return 0;
 

--- a/src/config.c
+++ b/src/config.c
@@ -54,6 +54,7 @@ struct config config = {
 	.log_syslog = true,
 	.default_duid = { 0 },
 	.default_duid_len = 0,
+	.boot_id = { 0 },
 };
 
 struct sys_conf sys_conf = {

--- a/src/config.c
+++ b/src/config.c
@@ -2090,18 +2090,18 @@ void odhcpd_reload(void)
 				set_config(s);
 		}
 
-		/* 2. DHCP pools */
-		uci_foreach_element(&dhcp->sections, e) {
-			struct uci_section *s = uci_to_section(e);
-			if (!strcmp(s->type, "dhcp"))
-				set_interface(s);
-		}
-
-		/* 3. Static lease cfgs */
+		/* 2. Static lease cfgs */
 		uci_foreach_element(&dhcp->sections, e) {
 			struct uci_section* s = uci_to_section(e);
 			if (!strcmp(s->type, "host"))
 				set_lease_cfg_from_uci(s);
+		}
+
+		/* 3. DHCP pools */
+		uci_foreach_element(&dhcp->sections, e) {
+			struct uci_section *s = uci_to_section(e);
+			if (!strcmp(s->type, "dhcp"))
+				set_interface(s);
 		}
 
 		/* 4. IPv6 PxE */

--- a/src/config.c
+++ b/src/config.c
@@ -42,8 +42,8 @@ struct config config = {
 #else
 	.use_ubus = false,
 #endif /* WITH_UBUS */
-	.dhcp_statefile = NULL,
-	.dhcp_statedir_fd = -1,
+	.dhcp_leasefile = NULL,
+	.dhcp_leasefiledir_fd = -1,
 	.dhcp_hostsdir = NULL,
 	.dhcp_hostsdir_fd = -1,
 	.ra_piodir = NULL,
@@ -459,8 +459,8 @@ static void set_config(struct uci_section *s)
 		config.main_dhcpv4 = blobmsg_get_bool(c);
 
 	if ((c = tb[ODHCPD_ATTR_LEASEFILE])) {
-		free(config.dhcp_statefile);
-		config.dhcp_statefile = strdup(blobmsg_get_string(c));
+		free(config.dhcp_leasefile);
+		config.dhcp_leasefile = strdup(blobmsg_get_string(c));
 	}
 
 	if ((c = tb[ODHCPD_ATTR_HOSTSDIR])) {
@@ -492,14 +492,14 @@ static void set_config(struct uci_section *s)
 	if ((c = tb[ODHCPD_ATTR_ENABLE_TZ]))
 		config.enable_tz = blobmsg_get_bool(c);
 
-	if (config.dhcp_statefile) {
-		char *dir = dirname(strdupa(config.dhcp_statefile));
-		char *file = basename(config.dhcp_statefile);
+	if (config.dhcp_leasefile) {
+		char *dir = dirname(strdupa(config.dhcp_leasefile));
+		char *file = basename(config.dhcp_leasefile);
 
-		memmove(config.dhcp_statefile, file, strlen(file) + 1);
-		statefiles_setup_dirfd(dir, &config.dhcp_statedir_fd);
+		memmove(config.dhcp_leasefile, file, strlen(file) + 1);
+		statefiles_setup_dirfd(dir, &config.dhcp_leasefiledir_fd);
 	} else {
-		statefiles_setup_dirfd(NULL, &config.dhcp_statedir_fd);
+		statefiles_setup_dirfd(NULL, &config.dhcp_leasefiledir_fd);
 	}
 	statefiles_setup_dirfd(config.dhcp_hostsdir, &config.dhcp_hostsdir_fd);
 	statefiles_setup_dirfd(config.ra_piodir, &config.ra_piodir_fd);

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -386,11 +386,11 @@ dhcpv4_alloc_lease(struct interface *iface, const struct ether_addr *macaddr,
 	return lease;
 }
 
-static bool dhcpv4_insert_lease(struct avl_tree *avl, struct dhcpv4_lease *lease,
-				struct in_addr addr)
+static bool
+dhcpv4_insert_lease(struct interface *iface, struct dhcpv4_lease *lease, struct in_addr addr)
 {
 	lease->ipv4 = addr;
-	if (!avl_insert(avl, &lease->iface_avl))
+	if (!avl_insert(&iface->dhcpv4_leases, &lease->iface_avl))
 		return true;
 	else
 		return false;
@@ -421,7 +421,7 @@ static bool dhcpv4_assign_random(struct interface *iface,
 		if (config_find_lease_cfg_by_ipv4(in_try))
 			continue;
 
-		if (dhcpv4_insert_lease(&iface->dhcpv4_leases, lease, in_try))
+		if (dhcpv4_insert_lease(iface, lease, in_try))
 			return true;
 	}
 
@@ -438,7 +438,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcpv4_lease *lease,
 
 	/* Preconfigured IP address by static lease */
 	if (lease->ipv4.s_addr) {
-		if (!dhcpv4_insert_lease(&iface->dhcpv4_leases, lease, lease->ipv4)) {
+		if (!dhcpv4_insert_lease(iface, lease, lease->ipv4)) {
 			error("The static IP address %s is already assigned on %s",
 			      inet_ntop(AF_INET, &lease->ipv4, ipv4_str, sizeof(ipv4_str)),
 			      iface->name);
@@ -464,7 +464,7 @@ static bool dhcpv4_assign(struct interface *iface, struct dhcpv4_lease *lease,
 			debug("The requested IP address %s is statically assigned on %s",
 			      inet_ntop(AF_INET, &req_addr, ipv4_str, sizeof(ipv4_str)),
 			      iface->ifname);
-		} else if (!dhcpv4_insert_lease(&iface->dhcpv4_leases, lease, req_addr)) {
+		} else if (!dhcpv4_insert_lease(iface, lease, req_addr)) {
 			debug("The requested IP address %s is already assigned on %s",
 			      inet_ntop(AF_INET, &req_addr, ipv4_str, sizeof(ipv4_str)),
 			      iface->ifname);

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -361,7 +361,7 @@ void dhcpv4_free_lease(struct dhcpv4_lease *lease)
 	free(lease);
 }
 
-static struct dhcpv4_lease *
+struct dhcpv4_lease *
 dhcpv4_alloc_lease(struct interface *iface, const struct ether_addr *macaddr,
 		   const uint8_t *duid, size_t duid_len, uint32_t iaid)
 {
@@ -386,7 +386,7 @@ dhcpv4_alloc_lease(struct interface *iface, const struct ether_addr *macaddr,
 	return lease;
 }
 
-static bool
+bool
 dhcpv4_insert_lease(struct interface *iface, struct dhcpv4_lease *lease, struct in_addr addr)
 {
 	lease->ipv4 = addr;

--- a/src/dhcpv4.h
+++ b/src/dhcpv4.h
@@ -188,4 +188,47 @@ struct dhcpv4_dnr {
 			&opt->data[opt->len] <= (end); \
 		opt = (struct dhcpv4_option*)&opt->data[opt->len])
 
+#ifdef DHCPV4_SUPPORT
+int dhcpv4_init(void);
+void dhcpv4_free_lease(struct dhcpv4_lease *a);
+struct dhcpv4_lease *dhcpv4_alloc_lease(struct interface *iface,
+					const struct ether_addr *macaddr,
+					const uint8_t *duid,
+					size_t duid_len,
+					uint32_t iaid);
+bool dhcpv4_insert_lease(struct interface *iface, struct dhcpv4_lease *lease,
+			 struct in_addr addr);
+bool dhcpv4_setup_interface(struct interface *iface, bool enable);
+void dhcpv4_handle_msg(void *addr, void *data, size_t len,
+		       struct interface *iface, _o_unused void *dest_addr,
+		       send_reply_cb_t send_reply, void *opaque);
+#else
+static inline void
+dhcpv4_free_lease(struct dhcpv4_lease *lease)
+{
+	return;
+}
+
+static inline struct dhcpv4_lease *
+dhcpv4_alloc_lease(struct interface *iface, const struct ether_addr *macaddr,
+		   const uint8_t *duid, size_t duid_len, uint32_t iaid)
+{
+	return NULL;
+}
+
+static inline bool
+dhcpv4_insert_lease(struct interface *iface, struct dhcpv4_lease *lease,
+		    struct in_addr addr)
+{
+	return false;
+}
+
+static inline bool
+dhcpv4_setup_interface(struct interface *iface, bool enable)
+{
+	return true;
+}
+
+#endif /* DHCPV4_SUPPORT */
+
 #endif /* _DHCPV4_H_ */

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -44,7 +44,7 @@ static struct netevent_handler dhcpv6_netevent_handler = { .cb = dhcpv6_netevent
 static struct uloop_timeout valid_until_timeout = {.cb = valid_until_cb};
 static uint32_t serial = 0;
 
-static struct dhcpv6_lease *
+struct dhcpv6_lease *
 dhcpv6_alloc_lease(size_t extra_len)
 {
 	struct dhcpv6_lease *a = calloc(1, sizeof(*a) + extra_len);
@@ -340,7 +340,7 @@ static void set_border_assignment_size(struct interface *iface, struct dhcpv6_le
 		b->assigned_subnet_id = 0;
 }
 
-static bool assign_pd(struct interface *iface, struct dhcpv6_lease *assign)
+bool assign_pd(struct interface *iface, struct dhcpv6_lease *assign)
 {
 	struct dhcpv6_lease *c;
 
@@ -413,7 +413,7 @@ static bool is_reserved_ipv6_iid(uint64_t iid)
 	return false;
 }
 
-static bool assign_na(struct interface *iface, struct dhcpv6_lease *a)
+bool assign_na(struct interface *iface, struct dhcpv6_lease *a)
 {
 	struct dhcpv6_lease *c;
 	uint64_t pool_start = 0x100;

--- a/src/dhcpv6-ia.h
+++ b/src/dhcpv6-ia.h
@@ -25,9 +25,9 @@ size_t get_preferred_addr(const struct odhcpd_ipaddr *addrs, const size_t addrle
 
 struct in6_addr in6_from_prefix_and_iid(const struct odhcpd_ipaddr *prefix, uint64_t iid);
 
-static inline bool valid_prefix_length(const struct dhcpv6_lease *a, const uint8_t prefix_length)
+static inline bool valid_prefix_length(const struct dhcpv6_lease *a, uint8_t prefix_len)
 {
-	return a->length > prefix_length;
+	return a->prefix_len > prefix_len;
 }
 
 static inline bool valid_addr(const struct odhcpd_ipaddr *addr, time_t now)

--- a/src/dhcpv6-ia.h
+++ b/src/dhcpv6-ia.h
@@ -21,9 +21,15 @@
 	 (i) == (m) || \
 	 (addrs)[(i)].prefix_len > 64)
 
+struct dhcpv6_lease *dhcpv6_alloc_lease(size_t extra_len);
+
 size_t get_preferred_addr(const struct odhcpd_ipaddr *addrs, const size_t addrlen);
 
 struct in6_addr in6_from_prefix_and_iid(const struct odhcpd_ipaddr *prefix, uint64_t iid);
+
+bool assign_pd(struct interface *iface, struct dhcpv6_lease *lease);
+
+bool assign_na(struct interface *iface, struct dhcpv6_lease *lease);
 
 static inline bool valid_prefix_length(const struct dhcpv6_lease *a, uint8_t prefix_len)
 {

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -694,12 +694,15 @@ void odhcpd_enum_addr6(struct interface *iface, struct dhcpv6_lease *lease,
 			continue;
 		}
 
-		if (lease->flags & OAF_DHCPV6_NA) {
+		switch (lease->type) {
+		case DHCPV6_IA_NA:
 			if (!ADDR_ENTRY_VALID_IA_ADDR(iface, i, m, addrs))
 				continue;
 
 			addr = in6_from_prefix_and_iid(&addrs[i], lease->assigned_host_id);
-		} else {
+			break;
+
+		case DHCPV6_IA_PD:
 			if (!valid_prefix_length(lease, addrs[i].prefix_len))
 				continue;
 

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -106,6 +106,20 @@ static bool ipv6_enabled(void)
 	return true;
 }
 
+static void read_boot_id(void)
+{
+	int fd;
+
+	fd = open("/proc/sys/kernel/random/boot_id", O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return;
+
+	if (read(fd, config.boot_id, sizeof(config.boot_id) - 1) <= 0)
+		warn("Failed to read boot_id");
+
+	close(fd);
+}
+
 int main(int argc, char **argv)
 {
 	int opt;
@@ -162,6 +176,8 @@ int main(int argc, char **argv)
 	}
 
 	uloop_init();
+
+	read_boot_id();
 
 	ioctl_sock = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 	if (ioctl_sock < 0)

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -44,6 +44,7 @@
 
 #include "odhcpd.h"
 #include "dhcpv6-ia.h"
+#include "dhcpv4.h"
 
 static int ioctl_sock = -1;
 

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -641,17 +641,6 @@ void odhcpd_hexlify(char *dst, const uint8_t *src, size_t len)
 	*dst = 0;
 }
 
-const char *odhcpd_print_mac(const uint8_t *mac, const size_t len)
-{
-	static char buf[32];
-
-	snprintf(buf, sizeof(buf), "%02x", mac[0]);
-	for (size_t i = 1, j = 2; i < len && j < sizeof(buf); i++, j += 3)
-		snprintf(buf + j, sizeof(buf) - j, ":%02x", mac[i]);
-
-	return buf;
-}
-
 int odhcpd_bmemcmp(const void *av, const void *bv, size_t bits)
 {
 	const uint8_t *a = av, *b = bv;

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -43,6 +43,7 @@
 #include <libubox/uloop.h>
 
 #include "odhcpd.h"
+#include "dhcpv4.h"
 #include "dhcpv6-ia.h"
 #include "dhcpv4.h"
 

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -680,7 +680,7 @@ void odhcpd_enum_addr6(struct interface *iface, struct dhcpv6_lease *lease,
 	for (size_t i = 0; i < iface->addr6_len; ++i) {
 		struct in6_addr addr;
 		uint32_t preferred_lt, valid_lt;
-		int prefix = lease->length;
+		int prefix_len = 128;
 
 		if (!valid_addr(&addrs[i], now))
 			continue;
@@ -709,6 +709,7 @@ void odhcpd_enum_addr6(struct interface *iface, struct dhcpv6_lease *lease,
 			addr = addrs[i].addr.in6;
 			addr.s6_addr32[1] |= htonl(lease->assigned_subnet_id);
 			addr.s6_addr32[2] = addr.s6_addr32[3] = 0;
+			prefix_len = lease->prefix_len;
 		}
 
 		preferred_lt = addrs[i].preferred_lt;
@@ -728,7 +729,7 @@ void odhcpd_enum_addr6(struct interface *iface, struct dhcpv6_lease *lease,
 		if (valid_lt != UINT32_MAX)
 			valid_lt -= now;
 
-		func(lease, &addr, prefix, preferred_lt, valid_lt, arg);
+		func(lease, &addr, prefix_len, preferred_lt, valid_lt, arg);
 	}
 }
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -647,23 +647,6 @@ int router_init(void);
 int dhcpv6_init(void);
 int ndp_init(void);
 
-#ifdef DHCPV4_SUPPORT
-int dhcpv4_init(void);
-void dhcpv4_free_lease(struct dhcpv4_lease *a);
-bool dhcpv4_setup_interface(struct interface *iface, bool enable);
-void dhcpv4_handle_msg(void *addr, void *data, size_t len,
-		       struct interface *iface, _o_unused void *dest_addr,
-		       send_reply_cb_t send_reply, void *opaque);
-#else
-static inline bool dhcpv4_setup_interface(struct interface *iface, bool enable) {
-	return true;
-}
-
-static inline void dhcpv4_free_lease(struct dhcpv4_lease *lease) {
-	error("Trying to free IPv4 assignment 0x%p", lease);
-}
-#endif /* DHCPV4_SUPPORT */
-
 int router_setup_interface(struct interface *iface, bool enable);
 int dhcpv6_setup_interface(struct interface *iface, bool enable);
 int ndp_setup_interface(struct interface *iface, bool enable);

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -262,8 +262,7 @@ struct dhcpv4_lease {
 	time_t valid_until;			// CLOCK_MONOTONIC time, 0 = inf
 	char *hostname;				// client hostname
 	bool hostname_valid;			// is the hostname one or more valid DNS labels?
-	size_t hwaddr_len;			// hwaddr length
-	uint8_t hwaddr[ETH_ALEN];		// hwaddr (only MAC supported)
+	struct ether_addr macaddr;		// MAC address
 
 	// ForceRenew Nonce - RFC6704 §3.1.2
 	struct uloop_timeout fr_timer;		// FR message transmission timer
@@ -319,10 +318,10 @@ struct lease_cfg {
 	struct dhcpv4_lease *dhcpv4_lease;
 	struct in_addr ipv4;
 	uint64_t hostid;
-	size_t mac_count;
-	struct ether_addr *macs;
-	size_t duid_count;
+	struct ether_addr *macaddrs;
+	size_t macaddrs_cnt;
 	struct duid *duids;
+	size_t duid_cnt;
 	uint32_t leasetime;		// duration of granted leases, UINT32_MAX = inf
 	char *hostname;
 	bool ignore4;
@@ -559,7 +558,6 @@ int odhcpd_run(void);
 time_t odhcpd_time(void);
 ssize_t odhcpd_unhexlify(uint8_t *dst, size_t len, const char *src);
 void odhcpd_hexlify(char *dst, const uint8_t *src, size_t len);
-const char *odhcpd_print_mac(const uint8_t *mac, const size_t len);
 
 int odhcpd_bmemcmp(const void *av, const void *bv, size_t bits);
 void odhcpd_bmemcpy(void *av, const void *bv, size_t bits);
@@ -577,7 +575,7 @@ int config_parse_interface(void *data, size_t len, const char *iname, bool overw
 struct lease_cfg *config_find_lease_cfg_by_duid_and_iaid(const uint8_t *duid,
 							 const uint16_t len,
 							 const uint32_t iaid);
-struct lease_cfg *config_find_lease_cfg_by_mac(const uint8_t *mac);
+struct lease_cfg *config_find_lease_cfg_by_macaddr(const struct ether_addr *macaddr);
 struct lease_cfg *config_find_lease_cfg_by_hostid(const uint64_t hostid);
 struct lease_cfg *config_find_lease_cfg_by_ipv4(const struct in_addr ipv4);
 int config_set_lease_cfg_from_blobmsg(struct blob_attr *ba);

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -54,7 +54,16 @@
 // RFC 9463 - Discovery of Network-designated Resolvers (DNR)
 #define ND_OPT_DNR 144
 
-#define INFINITE_VALID(x) ((x) == 0)
+// This is for CLOCK_MONOTONIC durations
+#define MONOTIME_INFINITY 0
+#define INFINITE_VALID(x) ((x) == MONOTIME_INFINITY)
+
+// This is for IPv6 preferred/valid lifetimes
+#define LIFETIME_INFINITY UINT32_MAX
+static inline bool lifetime_is_infinite(uint32_t lt)
+{
+	return lt == LIFETIME_INFINITY;
+}
 
 #ifndef _o_fallthrough
 #define _o_fallthrough __attribute__((__fallthrough__))

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -207,6 +207,9 @@ enum duid_type {
 	DUID_TYPE_UUID = 4,
 };
 
+/* Linux kernel boot_id = UUIDv4 */
+#define BOOT_ID_LEN 36
+
 struct config {
 	bool enable_tz;
 	bool main_dhcpv4;
@@ -228,6 +231,8 @@ struct config {
 
 	uint8_t default_duid[DUID_MAX_LEN];
 	size_t default_duid_len;
+
+	uint8_t boot_id[BOOT_ID_LEN + 1];
 };
 
 struct sys_conf {

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -307,10 +307,12 @@ struct dhcpv6_lease {
 	uint8_t key[16];
 
 	union {
-		uint64_t assigned_host_id;
-		uint32_t assigned_subnet_id;
+		uint64_t assigned_host_id;	// IA_NA
+		struct {			// IA_PD
+			uint32_t assigned_subnet_id;
+			uint8_t prefix_len;
+		};
 	};
-	uint8_t length; // length == 128 -> IA_NA, length <= 64 -> IA_PD
 
 	enum dhcpv6_lease_type type;
 	bool bound;				// the lease has been accepted by the client

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -188,12 +188,6 @@ enum odhcpd_mode {
 	MODE_HYBRID
 };
 
-
-enum odhcpd_assignment_flags {
-	OAF_DHCPV6_NA		= (1 << 0),
-	OAF_DHCPV6_PD		= (1 << 1),
-};
-
 /* 2-byte type + 128-byte DUID, RFC8415, §11.1 */
 #define DUID_MAX_LEN 130
 /* In theory, 2 (type only), or 7 (DUID-EN + 1-byte data), but be reasonable */
@@ -281,6 +275,11 @@ struct dhcpv4_lease {
 	uint8_t duid[];
 };
 
+enum dhcpv6_lease_type {
+	DHCPV6_IA_NA,
+	DHCPV6_IA_PD,
+};
+
 struct dhcpv6_lease {
 	struct list_head head;
 	struct list_head lease_cfg_list;
@@ -304,7 +303,7 @@ struct dhcpv6_lease {
 	};
 	uint8_t length; // length == 128 -> IA_NA, length <= 64 -> IA_PD
 
-	unsigned int flags;
+	enum dhcpv6_lease_type type;
 	bool bound;				// the lease has been accepted by the client
 	uint32_t leasetime;
 	char *hostname;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -216,8 +216,9 @@ struct config {
 	char *dhcp_cb;
 	bool use_ubus;
 
-	char *dhcp_statefile;
-	int dhcp_statedir_fd;
+	char *dhcp_leasefile;
+	int dhcp_leasefiledir_fd;
+
 	char *dhcp_hostsdir;
 	int dhcp_hostsdir_fd;
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -219,6 +219,9 @@ struct config {
 	char *dhcp_leasefile;
 	int dhcp_leasefiledir_fd;
 
+	char *statedir;
+	int statedir_fd;
+
 	char *dhcp_hostsdir;
 	int dhcp_hostsdir_fd;
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -289,6 +289,13 @@ enum dhcpv6_lease_type {
 	DHCPV6_IA_PD,
 };
 
+struct dhcpv6_ia {
+	time_t preferred_until;
+	time_t valid_until;
+	uint8_t prefix_len;
+	struct in6_addr addr;
+};
+
 struct dhcpv6_lease {
 	struct list_head head;
 	struct list_head lease_cfg_list;
@@ -313,6 +320,9 @@ struct dhcpv6_lease {
 			uint8_t prefix_len;
 		};
 	};
+
+	struct dhcpv6_ia *ias;			// IAs that have been given to the client
+	size_t ias_cnt;				// Count of IAs
 
 	enum dhcpv6_lease_type type;
 	bool bound;				// the lease has been accepted by the client

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -576,6 +576,7 @@ int odhcpd_parse_addr6_prefix(const char *str, struct in6_addr *addr, uint8_t *p
 bool odhcpd_hostname_valid(const char *name);
 
 int config_parse_interface(void *data, size_t len, const char *iname, bool overwrite);
+struct lease_cfg *config_find_lease_cfg_by_duid(const uint8_t *duid, const uint16_t len);
 struct lease_cfg *config_find_lease_cfg_by_duid_and_iaid(const uint8_t *duid,
 							 const uint16_t len,
 							 const uint32_t iaid);

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -523,7 +523,7 @@ static void statefiles_write_state4(struct write_ctxt *ctxt, struct dhcpv4_lease
 	fprintf(ctxt->fp,
 		"# %s %s ipv4 %s%s %" PRId64 " %x 32 %s/32\n",
 		ctxt->iface->ifname,
-		ether_ntoa((struct ether_addr *)lease->hwaddr),
+		ether_ntoa(&lease->macaddr),
 		lease->hostname && !lease->hostname_valid ? "broken\\x20" : "",
 		lease->hostname ? lease->hostname : "-",
 		(lease->valid_until > ctxt->now ?

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -373,7 +373,7 @@ static bool statefiles_write_host6(struct write_ctxt *ctxt, struct dhcpv6_lease 
 {
 	char ipbuf[INET6_ADDRSTRLEN];
 
-	if (!lease->hostname || !lease->hostname_valid || !(lease->flags & OAF_DHCPV6_NA))
+	if (!lease->hostname || !lease->hostname_valid || lease->type != DHCPV6_IA_NA)
 		return false;
 
 	if (ctxt->fp) {
@@ -465,7 +465,7 @@ static void statefiles_write_lease6_addr(struct dhcpv6_lease *lease, struct in6_
 	struct write_ctxt *ctxt = (struct write_ctxt *)arg;
 	char ipbuf[INET6_ADDRSTRLEN];
 
-	if (lease->hostname && lease->hostname_valid && lease->flags & OAF_DHCPV6_NA) {
+	if (lease->hostname && lease->hostname_valid && lease->type == DHCPV6_IA_NA) {
 		md5_hash(addr, sizeof(*addr), &ctxt->md5);
 		md5_hash(lease->hostname, strlen(lease->hostname), &ctxt->md5);
 	}
@@ -493,9 +493,8 @@ static void statefiles_write_lease6(struct write_ctxt *ctxt, struct dhcpv6_lease
 			(lease->valid_until > ctxt->now ?
 			 (int64_t)(lease->valid_until - ctxt->now + ctxt->wall_time) :
 			 (INFINITE_VALID(lease->valid_until) ? -1 : 0)),
-			(lease->flags & OAF_DHCPV6_NA ?
-			 lease->assigned_host_id :
-			 (uint64_t)lease->assigned_subnet_id),
+			lease->type == DHCPV6_IA_NA ?
+			lease->assigned_host_id : (uint64_t)lease->assigned_subnet_id,
 			lease->length);
 	}
 

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -495,7 +495,8 @@ static void statefiles_write_lease6(struct write_ctxt *ctxt, struct dhcpv6_lease
 			 (INFINITE_VALID(lease->valid_until) ? -1 : 0)),
 			lease->type == DHCPV6_IA_NA ?
 			lease->assigned_host_id : (uint64_t)lease->assigned_subnet_id,
-			lease->length);
+			lease->type == DHCPV6_IA_NA ?
+			128 : lease->prefix_len);
 	}
 
 	odhcpd_enum_addr6(ctxt->iface, lease, ctxt->now, statefiles_write_lease6_addr, ctxt);

--- a/src/statefiles.h
+++ b/src/statefiles.h
@@ -9,12 +9,16 @@
 #define _STATEFILES_H_
 
 #define ODHCPD_HOSTS_FILE_PREFIX "odhcpd.hosts"
+#define ODHCPD_STATE_FILE_PREFIX "odhcpd.state"
+#define ODHCPD_STATE_FILE_VERSION 1
 #define ODHCPD_PIO_FILE_PREFIX "odhcpd.pio"
 #define ODHCPD_TMP_FILE ".odhcpd.tmp"
 
 void statefiles_read_prefix_information(struct interface *iface);
 
 void statefiles_write_prefix_information(struct interface *iface);
+
+void statefiles_read(struct interface *iface);
 
 bool statefiles_write(void);
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -43,10 +43,9 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _o_unused struct ubus_
 				continue;
 
 			void *m, *l = blobmsg_open_table(&b, NULL);
-			char *buf = blobmsg_alloc_string_buffer(&b, "mac", sizeof(c->hwaddr) * 2 + 1);
+			char *buf;
 
-			odhcpd_hexlify(buf, c->hwaddr, sizeof(c->hwaddr));
-			blobmsg_add_string_buffer(&b);
+			blobmsg_add_string(&b, "mac", ether_ntoa(&c->macaddr));
 
 			if (c->duid_len > 0) {
 				buf = blobmsg_alloc_string_buffer(&b, "duid", DUID_HEXSTRLEN + 1);
@@ -411,7 +410,7 @@ void ubus_bcast_dhcpv4_event(const char *type, const char *iface,
 	blob_buf_init(&b, 0);
 	blobmsg_add_string(&b, "interface", iface);
 	blobmsg_add_string(&b, "ipv4", inet_ntop(AF_INET, &lease->ipv4, ipv4_str, sizeof(ipv4_str)));
-	blobmsg_add_string(&b, "mac", odhcpd_print_mac(lease->hwaddr, sizeof(lease->hwaddr)));
+	blobmsg_add_string(&b, "mac", ether_ntoa(&lease->macaddr));
 	if (lease->hostname)
 		blobmsg_add_string(&b, "hostname", lease->hostname);
 	if (lease->duid_len > 0) {


### PR DESCRIPTION
This is a rough draft/WIP of code to store and persist all state of DHCPv[46] leases across a reboot/restart. Requires a lot more work to handle all corner cases (e.g. if interface addresses change across a reboot/restart, we need to handle that properly and trigger reconfiguration events for clients that support it, and probably drop leases for clients that don't, etc, etc, etc).