### PR TITLE
send DHCPv6 lease events over U-Bus

### DIFF
--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -510,6 +510,12 @@ void ubus_apply_network(void);
 bool ubus_has_prefix(const char *name, const char *ifname);
 void ubus_bcast_dhcp_event(const char *type, const uint8_t *mac, const size_t mac_len,
 		const struct in_addr *addr, const char *name, const char *interface);
+void ubus_bcast_dhcp6_event(
+	const char* type,
+	const struct dhcp_assignment *assignment,
+	size_t addrs_len,
+	const struct odhcpd_ipaddr addrs[static addrs_len]
+);
 #endif
 
 ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *iface,


### PR DESCRIPTION
odhcpd currently only sends DHCPv4 lease events over U-Bus. For DHCPv6 the only option was to use a trigger hook script and then parse a lease file and diff it against previous version.

This made it very inconvenient to use in cases like adding DHCP hosts to DNS server and the behavior is also inconsistent with DHCPv4 counterpart. Format of the U-Bus message is based on reply of `ipv6leases` U-Bus method.

This patch is largely based on https://github.com/mikma/openwrt-odhcpd/commit/b796d613dfe74fd36a8df8564c51907321f6a187