### PR TITLE
dhcpv4:  fix do_page_fault() when interface lost carrier

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -351,7 +351,6 @@ void dhcpv4_free_lease(struct dhcpv4_lease *lease)
 
 	if (lease->iface) {
 		lease->iface->update_statefile = true;
-		avl_delete(&lease->iface->dhcpv4_leases, &lease->iface_avl);
 	}
 
 	if (lease->lease_cfg)


### PR DESCRIPTION
This fix issue #371 . According to avl.h, av_delete can’t be called in remove all elements loop.