### PR TITLE
dhcpv4: Fix AVL tree corruption bugs

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1489,7 +1489,7 @@ bool dhcpv4_setup_interface(struct interface *iface, bool enable)
 	if (!enable || iface->dhcpv4 == MODE_DISABLED) {
 		struct dhcpv4_lease *lease, *tmp;
 
-		avl_remove_all_elements(&iface->dhcpv4_leases, lease, iface_avl, tmp)
+		avl_for_each_element_safe(&iface->dhcpv4_leases, lease, iface_avl, tmp)
 			dhcpv4_free_lease(lease);
 		return true;
 	}

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -349,7 +349,7 @@ void dhcpv4_free_lease(struct dhcpv4_lease *lease)
 	if (lease->fr_ip)
 		dhcpv4_fr_stop(lease);
 
-	if (lease->iface) {
+	if (avl_find(&lease->iface->dhcpv4_leases, &lease->ipv4) == &lease->iface_avl) {
 		lease->iface->update_statefile = true;
 		avl_delete(&lease->iface->dhcpv4_leases, &lease->iface_avl);
 	}


### PR DESCRIPTION
dhcpv4_free_lease already calls avl_delete() on the node it's freeing, and thus shouldn't be called inside an avl_remove_all_elements() loop.

Use avl_for_each_element_safe() instead. Its documentation says: "This loop can be used if the current element might be removed from the tree during the loop."

Fixes: https://github.com/openwrt/odhcpd/issues/371