### PR TITLE
ubus: fix truncated field in DHCPv6 lease query

### DIFF
--- a/src/ubus.c
+++ b/src/ubus.c
@@ -148,7 +148,7 @@ static int handle_dhcpv6_leases(_o_unused struct ubus_context *ctx, _o_unused st
 			if (a->flags & OAF_DHCPV6_NA)
 				blobmsg_add_u64(&b, "assigned", a->assigned_host_id);
 			else
-				blobmsg_add_u16(&b, "assigned", a->assigned_subnet_id);
+				blobmsg_add_u32(&b, "assigned", a->assigned_subnet_id);
 
 			m = blobmsg_open_array(&b, "flags");
 			if (a->bound)


### PR DESCRIPTION
The `assigned_subnet_id` field in `struct dhcpv6_lease` is `uint32_t`, not `uint16_t`.

Unlikely to matter in practice, since the number of meaningful bits in the field is `(assignment size) - (interface assignemt size)`, so largest typically be `64 - 48 = 16`. But it is possible to assign a /32 to an interface in openwrt.