### PR TITLE
odhcpd: Ignore NULL in dhcpv4_free_lease() stub

### DIFF
--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -655,6 +655,8 @@ static inline bool dhcpv4_setup_interface(struct interface *iface, bool enable) 
 }
 
 static inline void dhcpv4_free_lease(struct dhcpv4_lease *lease) {
+	if (!lease)
+		return;
 	error("Trying to free IPv4 assignment 0x%p", lease);
 }
 #endif /* DHCPV4_SUPPORT */


### PR DESCRIPTION
When `DHCPV4_SUPPORT` is not defined, a stub implementation of `dhcpv4_free_lease()` is provided that logs an error when it's called. A couple sites in config.c unconditionally free the `dhcpv4_lease` field of `struct lease_cfg`, causing log spam like:
> Trying to free IPv4 assignment 0x(nil)

Silence by making the stub a noop if the argument is NULL, just like the actual implementation.

Fixes: https://github.com/openwrt/odhcpd/issues/382