### PR TITLE
odhcpd: ensure zero padding on DNSSL

### DIFF
--- a/src/router.c
+++ b/src/router.c
@@ -920,6 +920,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	if (iface->ra_dns && iface->dns_search_len > 0) {
 		search_sz = sizeof(*search) + ((iface->dns_search_len + 7) & ~7);
 		search = alloca(search_sz);
+		memset(search, 0, search_sz);
 		*search = (struct nd_opt_search_list) {
 			.type = ND_OPT_DNS_SEARCH,
 			.len = search_sz / 8,


### PR DESCRIPTION
From https://www.rfc-editor.org/rfc/rfc8106#section-5.2 regarding the DNSSL field:

  Because the size of this field MUST be a multiple of
  8 octets, for the minimum multiple including the domain
  name representations, the remaining octets other than the
  encoding parts of the domain name representations MUST be
  padded with zeros.

The current code leaves the trailing octets in uninitialized state, resulting in parsing errors on (at least) systemd RA clients. This commit restores the explicit zeroing of the trailing octets.

Fixes: https://github.com/openwrt/odhcpd/commit/0a54ce0
Fixes: https://github.com/openwrt/openwrt/issues/22351

---
Tested on x86/64 snapshot:
```
$ tcpdump -v -n -p 'icmp6[icmp6type] == icmp6-routeradvert' -i br-lan -X -s0
tcpdump: listening on br-lan, link-type EN10MB (Ethernet), snapshot length 262144 bytes
06:52:22.514144 IP6 (flowlabel 0x6e2ab, hlim 255, next-header ICMPv6 (58), payload length 256) fe80::7e2b:e1ff:fe13:73a8 > ff02::1: [icmp6 sum ok] ICMP6, router advertisement, length 256
...
          dnssl option (31), length 24 (3):  lifetime 5163s, domain(s): xxx.lan.
...
        0x0100:                      1f03 0000 0000 142b  ...............+
        0x0110:  0378 7878 036c 616e 0000 0000 0000 0000  .xxx.lan........
```