### PR TITLE
[25.12] backport fixes from master

### DIFF
--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -1489,7 +1489,7 @@ bool dhcpv4_setup_interface(struct interface *iface, bool enable)
 	if (!enable || iface->dhcpv4 == MODE_DISABLED) {
 		struct dhcpv4_lease *lease, *tmp;
 
-		avl_remove_all_elements(&iface->dhcpv4_leases, lease, iface_avl, tmp)
+		avl_for_each_element_safe(&iface->dhcpv4_leases, lease, iface_avl, tmp)
 			dhcpv4_free_lease(lease);
 		return true;
 	}

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -349,7 +349,7 @@ void dhcpv4_free_lease(struct dhcpv4_lease *lease)
 	if (lease->fr_ip)
 		dhcpv4_fr_stop(lease);
 
-	if (lease->iface) {
+	if (avl_find(&lease->iface->dhcpv4_leases, &lease->ipv4) == &lease->iface_avl) {
 		lease->iface->update_statefile = true;
 		avl_delete(&lease->iface->dhcpv4_leases, &lease->iface_avl);
 	}

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -824,6 +824,7 @@ static size_t build_ia(uint8_t *buf, size_t buflen, uint16_t status,
 struct log_ctxt {
 	char *buf;
 	int buf_len;
+	/* if full, buf_idx will point to the last valid memory in buf */
 	int buf_idx;
 };
 
@@ -832,10 +833,20 @@ static void dhcpv6_log_ia_addr(_o_unused struct dhcpv6_lease *lease, struct in6_
 {
 	struct log_ctxt *ctxt = (struct log_ctxt *)arg;
 	char addrbuf[INET6_ADDRSTRLEN];
+	int ret;
+
+	/* Log buffer full */
+	if (ctxt->buf_idx >= ctxt->buf_len - 1)
+		return;
 
 	inet_ntop(AF_INET6, addr, addrbuf, sizeof(addrbuf));
-	ctxt->buf_idx += snprintf(ctxt->buf + ctxt->buf_idx, ctxt->buf_len - ctxt->buf_idx,
-				  " %s/%" PRIu8, addrbuf, prefix_len);
+	ret = snprintf(ctxt->buf + ctxt->buf_idx, ctxt->buf_len - ctxt->buf_idx,
+		       " %s/%" PRIu8, addrbuf, prefix_len);
+
+	if (ret + ctxt->buf_idx < ctxt->buf_len - 1)
+		ctxt->buf_idx += ret;
+	else
+		ctxt->buf_idx = ctxt->buf_len - 1;
 }
 
 static void dhcpv6_log(uint8_t msgtype, struct interface *iface, time_t now,

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -655,6 +655,8 @@ static inline bool dhcpv4_setup_interface(struct interface *iface, bool enable) 
 }
 
 static inline void dhcpv4_free_lease(struct dhcpv4_lease *lease) {
+	if (!lease)
+		return;
 	error("Trying to free IPv4 assignment 0x%p", lease);
 }
 #endif /* DHCPV4_SUPPORT */

--- a/src/router.c
+++ b/src/router.c
@@ -920,6 +920,7 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	if (iface->ra_dns && iface->dns_search_len > 0) {
 		search_sz = sizeof(*search) + ((iface->dns_search_len + 7) & ~7);
 		search = alloca(search_sz);
+		memset(search, 0, search_sz);
 		*search = (struct nd_opt_search_list) {
 			.type = ND_OPT_DNS_SEARCH,
 			.len = search_sz / 8,

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -148,7 +148,7 @@ static int handle_dhcpv6_leases(_o_unused struct ubus_context *ctx, _o_unused st
 			if (a->flags & OAF_DHCPV6_NA)
 				blobmsg_add_u64(&b, "assigned", a->assigned_host_id);
 			else
-				blobmsg_add_u16(&b, "assigned", a->assigned_subnet_id);
+				blobmsg_add_u32(&b, "assigned", a->assigned_subnet_id);
 
 			m = blobmsg_open_array(&b, "flags");
 			if (a->bound)


### PR DESCRIPTION
- odhcpd: ensure zero padding on DNSSL
- odhcpd: ignore NULL in dhcpv4_free_lease() stub
- ubus: fix truncated field in DHCPv6 lease query
- dhcpv4: fix avl_delete on leases not in avl tree
- dhcpv4: fix segfault when disabling interface
- dhcpv6-ia: dhcpv6_log_ia_addr(): parse return of snprintf

CC @lynxis @aparcar 