### PR TITLE
dhcpv6-ia: send ubus notifications for DHCPv6 lease events

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,5 +181,7 @@ odhcpd currently broadcasts the following events via ubus:
 | `dhcp.lease4`	| `mac,ip,name,interface`	| A new DHCPv4 lease has been created |
 | `dhcp.release4`| `mac,ip,name,interface`	| A DHCPv4 lease has been released by a client |
 | `dhcp.expire4`| `mac,ip,name,interface`	| A DHCPv4 lease has expired |
+| `dhcp.lease6`	| `ip,name,interface`       | A new DHCPv6 lease has been created |
+| `dhcp.expire6`| `ip,name,interface`       | A DHCPv6 lease has expired or has been released by a client |
 
 These can be observed by running e.g. `ubus listen dhcp` on your OpenWrt device.

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -556,8 +556,10 @@ static void valid_until_cb(struct uloop_timeout *event)
 			continue;
 
 		list_for_each_entry_safe(a, n, &iface->ia_assignments, head) {
-			if (a->duid_len > 0 && !INFINITE_VALID(a->valid_until) && a->valid_until < now)
+			if (a->duid_len > 0 && !INFINITE_VALID(a->valid_until) && a->valid_until < now) {
+				ubus_bcast_dhcpv6_event("dhcp.expire6", iface->ifname, a);
 				dhcpv6_free_lease(a);
+			}
 		}
 	}
 	uloop_timeout_set(event, 1000);
@@ -1301,6 +1303,7 @@ proceed:
 					a->accept_fr_nonce = accept_reconf;
 					a->bound = true;
 					apply_lease(a, true);
+					ubus_bcast_dhcpv6_event("dhcp.lease6", iface->ifname, a);
 					break;
 
 				default:
@@ -1331,6 +1334,7 @@ proceed:
 
 				a->bound = true;
 				apply_lease(a, true);
+				ubus_bcast_dhcpv6_event("dhcp.lease6", iface->ifname, a);
 				break;
 
 			case DHCPV6_MSG_RELEASE:

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -586,6 +586,8 @@ void ubus_apply_network(void);
 bool ubus_has_prefix(const char *name, const char *ifname);
 void ubus_bcast_dhcpv4_event(const char *type, const char *iface,
 			     const struct dhcpv4_lease *lease);
+void ubus_bcast_dhcpv6_event(const char *type, const char *iface,
+			     struct dhcpv6_lease *lease);
 #else
 static inline int ubus_init(void)
 {
@@ -610,6 +612,13 @@ static inline bool ubus_has_prefix(const char *name, const char *ifname)
 static inline
 void ubus_bcast_dhcpv4_event(const char *type, const char *iface,
 			     const struct dhcpv4_lease *lease)
+{
+	return;
+}
+
+static inline
+void ubus_bcast_dhcpv6_event(const char *type, const char *iface,
+			     struct dhcpv6_lease *lease)
 {
 	return;
 }

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -109,6 +109,21 @@ static void dhcpv6_blobmsg_ia_addr(_o_unused struct dhcpv6_lease *lease, struct 
 	blobmsg_close_table(&b, a);
 }
 
+static void dhcpv6_blobmsg_ia_addr_short(_o_unused struct dhcpv6_lease *lease, struct in6_addr *addr, uint8_t prefix_len,
+					 _o_unused uint32_t pref_lt, _o_unused uint32_t valid_lt, _o_unused void *arg)
+{
+	void *a	= blobmsg_open_table(&b, NULL);
+	char *buf = blobmsg_alloc_string_buffer(&b, "address", INET6_ADDRSTRLEN);
+
+	inet_ntop(AF_INET6, addr, buf, INET6_ADDRSTRLEN);
+	blobmsg_add_string_buffer(&b);
+
+	if (prefix_len != 128)
+		blobmsg_add_u32(&b, "prefix-length", prefix_len);
+
+	blobmsg_close_table(&b, a);
+}
+
 static int handle_dhcpv6_leases(_o_unused struct ubus_context *ctx, _o_unused struct ubus_object *obj,
 		_o_unused struct ubus_request_data *req, _o_unused const char *method,
 		_o_unused struct blob_attr *msg)
@@ -420,6 +435,36 @@ void ubus_bcast_dhcpv4_event(const char *type, const char *iface,
 		blobmsg_add_string_buffer(&b);
 		blobmsg_add_u32(&b, "iaid", lease->iaid);
 	}
+
+	ubus_notify(ubus, &main_object, type, b.head, -1);
+}
+
+void ubus_bcast_dhcpv6_event(const char *type, const char *iface,
+			     struct dhcpv6_lease *lease)
+{
+	time_t now = odhcpd_time();
+	char *buf;
+	void *m;
+
+	if (!ubus || !main_object.has_subscribers || !iface)
+		return;
+
+	blob_buf_init(&b, 0);
+
+	blobmsg_add_string(&b, "interface", iface);
+
+	m = blobmsg_open_array(&b, lease->flags & OAF_DHCPV6_NA ? "ipv6-addr": "ipv6-prefix");
+	odhcpd_enum_addr6(lease->iface, lease, now, dhcpv6_blobmsg_ia_addr_short, m);
+	blobmsg_close_array(&b, m);
+
+	if (lease->hostname)
+		blobmsg_add_string(&b, "hostname", lease->hostname);
+
+	buf = blobmsg_alloc_string_buffer(&b, "duid", DUID_HEXSTRLEN + 1);
+	odhcpd_hexlify(buf, lease->duid, lease->duid_len);
+	blobmsg_add_string_buffer(&b);
+
+	blobmsg_add_u32(&b, "iaid", ntohl(lease->iaid));
 
 	ubus_notify(ubus, &main_object, type, b.head, -1);
 }


### PR DESCRIPTION
Send ubus notifications for DHCPv6 leases, similarly to DHCPv4 leases:

  - "dhcp.lease6" when a DHCPv6 lease is created or renewed,
  - "dhcp.expire6" when a DHCPv6 lease expires or is released.

A separate "dhcp.release6" notification is not implemented because dhcpv6_ia_handle_IAs() treats DHCPv6 RELEASE messages as immediate expiry, making it impossible to distinguish release from expiry without further code changes.

---

This is the same feature as proposed in #369, but implemented from scratch for consistency with odhcpd's existing concepts and code.

I tested this PR on a small home network and it seems to behave as advertised for address leases (`IA_NA`).

I openly admit that I have *not* tested this PR with DHCPv6-PD clients (`IA_PD`).