### PR TITLE
router: add option to include static routes in RA

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ and may also receive information from ubus
 [//]: # "dhcpv6_raw - string - not documented, may change when generic DHCPv4/DHCPv6 options are added"
 
 
+### Sections of type ra_route
+| Option	| Type		| Default		| Description |
+| :------------ | :------------ | :-------------------- | :---------- |
+| prefix	| string	| (none)		| Target IPv6 route prefix, e.g. `2000:abc::/48`. |
+| interface	| list		| (none)		| List of interfaces to advertise this route on. If no interface is provided, the route is advertised on all interfaces. |
+| preference	| string	| `ra_preference`	| Route preference [medium\|high\|low]. By default interface-specific `ra_preference` value is used. |
+| lifetime	| string	| `ra_lifetime`	| Value to be placed in the Route Lifetime field of the Route Information. Implicitly clamped to the interval of sending unsolicited RA (`ra_maxinterval`) as a minimum value. Expected format follows `leasetime`, e.g. 60m, 2h, 3d, 1w. |
+
+
 ### Sections of type host (static leases)
 | Option		| Type	|Default| Description |
 | :-------------------- | :---- | :---- | :---------- |

--- a/src/config.c
+++ b/src/config.c
@@ -215,6 +215,26 @@ const struct uci_blob_param_list lease_cfg_attr_list = {
 };
 
 enum {
+	RA_ROUTE_ATTR_PREFIX,
+	RA_ROUTE_ATTR_INTERFACE,
+	RA_ROUTE_ATTR_PREFERENCE,
+	RA_ROUTE_ATTR_LIFETIME,
+	RA_ROUTE_ATTR_MAX
+};
+
+static const struct blobmsg_policy ra_route_attrs[RA_ROUTE_ATTR_MAX] = {
+	[RA_ROUTE_ATTR_PREFIX] = { .name = "prefix", .type = BLOBMSG_TYPE_STRING },
+	[RA_ROUTE_ATTR_INTERFACE] = { .name = "interface", .type = BLOBMSG_TYPE_ARRAY },
+	[RA_ROUTE_ATTR_PREFERENCE] = { .name = "preference", .type = BLOBMSG_TYPE_STRING },
+	[RA_ROUTE_ATTR_LIFETIME] = { .name = "lifetime", .type = BLOBMSG_TYPE_STRING },
+};
+
+const struct uci_blob_param_list ra_route_attr_list = {
+	.n_params = RA_ROUTE_ATTR_MAX,
+	.params = ra_route_attrs,
+};
+
+enum {
 	ODHCPD_ATTR_MAINDHCP,
 	ODHCPD_ATTR_LEASEFILE,
 	ODHCPD_ATTR_LEASETRIGGER,
@@ -314,6 +334,8 @@ static void set_interface_defaults(struct interface *iface)
 	iface->learn_routes = 1;
 	iface->ndp_from_link_local = true;
 	iface->cached_linklocal_valid = false;
+	iface->ra_static_routes = NULL;
+	iface->ra_static_routes_cnt = 0;
 	iface->dhcp_leasetime = 43200;
 	iface->max_preferred_lifetime = ND_PREFERRED_LIMIT;
 	iface->max_valid_lifetime = ND_VALID_LIMIT;
@@ -347,13 +369,14 @@ static void clean_interface(struct interface *iface)
 	free(iface->dns_addrs6);
 	free(iface->dns_search);
 	free(iface->upstream);
+	free(iface->ra_static_routes);
 	free(iface->dhcpv4_routers);
 	free(iface->dhcpv6_raw);
 	free(iface->dhcpv4_ntp);
 	free(iface->dhcpv6_ntp);
 	free(iface->dhcpv6_sntp);
 	free(iface->captive_portal_uri);
-	for (unsigned i = 0; i < iface->dnr_cnt; i++) {
+	for (size_t i = 0; i < iface->dnr_cnt; i++) {
 		free(iface->dnr[i].adn);
 		free(iface->dnr[i].addr4);
 		free(iface->dnr[i].addr6);
@@ -421,6 +444,60 @@ static int parse_ra_flags(uint8_t *flags, struct blob_attr *attr)
 
 		if (!ra_flags[i].name)
 			return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * Parses static route prefix from attribute to `route`
+ *
+ * Returns: 0 on success, -1 on failure
+ */
+static int parse_ra_route_prefix(struct blob_attr *attr, struct odhcpd_ip6prefix *route)
+{
+	const char *str = blobmsg_get_string(attr);
+
+	/* Parse the address and prefix length */
+	if (odhcpd_parse_addr6_prefix(str, &(route->addr), &(route->len)) < 0) {
+		return -1;
+	}
+
+	/*
+	 * Validate prefix length
+	 * Default route (::/0) is managed elsewhere.
+	 */
+	if (route->len == 0 || route->len > 128) {
+		return -1;
+	}
+
+	/*
+	 * Validate address
+	 * Zero-address (::) specifies default route and is managed elsewhere,
+	 * loopback and link-local addresses are not routable.
+	 */
+	if (IN6_IS_ADDR_UNSPECIFIED(&(route->addr)) ||
+	    IN6_IS_ADDR_LOOPBACK(&(route->addr)) ||
+	    IN6_IS_ADDR_LINKLOCAL(&(route->addr))) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static int parse_ra_route_preference(struct blob_attr *attr, int8_t *preference)
+{
+	const char *str = blobmsg_get_string(attr);
+
+	if (!strcmp(str, "high")) {
+		*preference = 1;
+	} else if (!strcmp(str, "medium")) {
+		*preference = 0;
+	} else if (!strcmp(str, "low")) {
+		*preference = -1;
+	} else {
+		// Invalid preference value
+		return -1;
 	}
 
 	return 0;
@@ -1966,6 +2043,135 @@ struct lease_cfg *config_find_lease_cfg_by_ipv4(const struct in_addr ipv4)
 	return NULL;
 }
 
+static int append_ra_route_to_interface(const char *name,
+					const struct odhcpd_ra_route *route,
+					bool preference_set)
+{
+	struct interface *iface;
+	iface = avl_find_element(&interfaces, name, iface, avl);
+
+	if (!iface) {
+		error("Interface '%s' not found for RA route", name);
+		return -1;
+	}
+
+	struct odhcpd_ra_route r = *route;
+
+	if (!preference_set) {
+		/* Inherit route preference */
+		r.preference = iface->route_preference;
+	}
+
+	if (r.lifetime == 0) {
+		/* Set default lifetime */
+		r.lifetime = iface->ra_lifetime;
+	} else if (r.lifetime < iface->ra_maxinterval) {
+		/* Ensure route lifetime is not less than the interface's maximum RA interval */
+		r.lifetime = iface->ra_maxinterval;
+	}
+
+	/* Append the route to the interface's RA routes */
+	struct odhcpd_ra_route *tmp = realloc(iface->ra_static_routes,
+		(iface->ra_static_routes_cnt + 1) * sizeof(*iface->ra_static_routes));
+	if (!tmp) {
+		error("Failed to allocate memory for RA route on interface '%s'", name);
+		return -1;
+	}
+
+	iface->ra_static_routes = tmp;
+	iface->ra_static_routes[iface->ra_static_routes_cnt] = r;
+	iface->ra_static_routes_cnt++;
+
+	/* Print the route */
+	char addr_str[INET6_ADDRSTRLEN];
+	inet_ntop(AF_INET6, &r.prefix.addr, addr_str, sizeof(addr_str));
+	info("Added static RA route %s/%u with preference %d and lifetime %" PRIu32
+	     " to interface '%s'",
+	     addr_str, r.prefix.len, r.preference, r.lifetime,
+	     name);
+
+	return 0;
+}
+
+static int config_parse_ra_route(void *data, size_t len, const char *section_name)
+{
+	struct blob_attr *tb[RA_ROUTE_ATTR_MAX], *c;
+	blobmsg_parse(ra_route_attrs, RA_ROUTE_ATTR_MAX, tb, data, len);
+
+	bool preference_set = false;
+	struct odhcpd_ra_route route = {};
+
+	if ((c = tb[RA_ROUTE_ATTR_PREFIX])) {
+		if (parse_ra_route_prefix(c, &route.prefix) != 0) {
+			error("Invalid %s value (%s) configured for RA route '%s'",
+			      ra_route_attrs[RA_ROUTE_ATTR_PREFIX].name,
+			      blobmsg_get_string(c), section_name);
+			return -1;
+		}
+	} else {
+		error("Missing required attribute '%s' for RA route '%s'",
+		      ra_route_attrs[RA_ROUTE_ATTR_PREFIX].name, section_name);
+		return -1;
+	}
+
+	if ((c = tb[RA_ROUTE_ATTR_PREFERENCE])) {
+		if (parse_ra_route_preference(c, &route.preference) == 0) {
+			preference_set = true;
+		} else {
+			warn("Invalid %s value (%s) configured for RA route '%s', using default",
+			     ra_route_attrs[RA_ROUTE_ATTR_PREFERENCE].name,
+			     blobmsg_get_string(c), section_name);
+		}
+	}
+
+	if ((c = tb[RA_ROUTE_ATTR_LIFETIME])) {
+		route.lifetime = parse_leasetime(c);
+
+		if (route.lifetime == 0) {
+			warn("Invalid %s value (%s) configured for RA route '%s', using default",
+			     ra_route_attrs[RA_ROUTE_ATTR_LIFETIME].name,
+			     blobmsg_get_string(c), section_name);
+		}
+	}
+
+	/* Append the route to the specified interfaces, or to all interfaces if none specified */
+	if ((c = tb[RA_ROUTE_ATTR_INTERFACE])) {
+		struct blob_attr *cur;
+		unsigned rem;
+
+		blobmsg_for_each_attr(cur, c, rem) {
+			if (blobmsg_type(cur) != BLOBMSG_TYPE_STRING ||
+			    !blobmsg_check_attr(cur, false)) {
+				continue;
+			}
+
+			const char *ifname = blobmsg_get_string(cur);
+			if (append_ra_route_to_interface(ifname, &route, preference_set) != 0) {
+				error("Failed to add RA route '%s' to interface '%s'",
+				      section_name, ifname);
+			}
+		}
+	} else {
+		struct interface *iface;
+		avl_for_each_element(&interfaces, iface, avl) {
+			if (append_ra_route_to_interface(iface->name, &route, preference_set) != 0) {
+				error("Failed to add RA route '%s' to interface '%s'",
+				      section_name, iface->name);
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int set_ra_route(struct uci_section *s)
+{
+	blob_buf_init(&b, 0);
+	uci_to_blob(&b, s, &ra_route_attr_list);
+
+	return config_parse_ra_route(blob_data(b.head), blob_len(b.head), s->e.name);
+}
+
 void reload_services(struct interface *iface)
 {
 	if (iface->ifflags & IFF_RUNNING) {
@@ -2070,7 +2276,17 @@ void odhcpd_reload(void)
 				set_lease_cfg_from_uci(s);
 		}
 
-		/* 4. IPv6 PxE */
+		/* 4. RA routes (depends on parsed interfaces) */
+		if (!avl_is_empty(&interfaces)) {
+			uci_foreach_element(&dhcp->sections, e) {
+				struct uci_section* s = uci_to_section(e);
+				if (!strcmp(s->type, "ra_route")) {
+					set_ra_route(s);
+				}
+			}
+		}
+
+		/* 5. IPv6 PxE */
 		ipv6_pxe_clear();
 		uci_foreach_element(&dhcp->sections, e) {
 			struct uci_section* s = uci_to_section(e);
@@ -2085,7 +2301,7 @@ void odhcpd_reload(void)
 	if (config.enable_tz && !uci_load(uci, uci_system_path, &system)) {
 		struct uci_element *e;
 
-		/* 5. System settings */
+		/* 6. System settings */
 		uci_foreach_element(&system->sections, e) {
 			struct uci_section *s = uci_to_section(e);
 			if (!strcmp(s->type, "system"))

--- a/src/config.c
+++ b/src/config.c
@@ -2216,6 +2216,8 @@ void odhcpd_reload(void)
 	if (!uci)
 		return;
 
+	notice("Reloading...");
+
 	if (config.uci_cfgdir) {
 		size_t dlen = strlen(config.uci_cfgdir);
 

--- a/src/config.c
+++ b/src/config.c
@@ -1760,17 +1760,10 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	}
 
 	if ((c = tb[IFACE_ATTR_RA_PREFERENCE])) {
-		const char *prio = blobmsg_get_string(c);
-
-		if (!strcmp(prio, "high"))
-			iface->route_preference = 1;
-		else if (!strcmp(prio, "low"))
-			iface->route_preference = -1;
-		else if (!strcmp(prio, "medium") || !strcmp(prio, "default"))
-			iface->route_preference = 0;
-		else
+		if (parse_ra_route_preference(c, &iface->route_preference)) {
 			error("Invalid %s mode configured for interface '%s'",
 			      iface_attrs[IFACE_ATTR_RA_PREFERENCE].name, iface->name);
+		}
 	}
 
 	if ((c = tb[IFACE_ATTR_NDPROXY_ROUTING]))

--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -752,6 +752,15 @@ int odhcpd_parse_addr6_prefix(const char *str, struct in6_addr *addr, uint8_t *p
 		return -1;
 	}
 
+	/* Ensure the address is properly masked */
+	uint8_t mask_bits_rem = *prefix;
+	for (uint8_t i = 0; i < sizeof(addr->s6_addr); i++) {
+		uint8_t b = (mask_bits_rem > 8) ? 8 : mask_bits_rem;
+		uint8_t mask_part = (uint8_t)(0xFF << (8 - b));
+		addr->s6_addr[i] = addr->s6_addr[i] & mask_part;
+		mask_bits_rem -= b;
+	}
+
 	return 0;
 }
 

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -181,6 +181,17 @@ struct odhcpd_ipaddr {
 	};
 };
 
+struct odhcpd_ip6prefix {
+	struct in6_addr addr;
+	uint8_t len;
+};
+
+struct odhcpd_ra_route {
+	struct odhcpd_ip6prefix prefix;
+	int8_t preference;
+	uint32_t lifetime;
+};
+
 enum odhcpd_mode {
 	MODE_DISABLED,
 	MODE_SERVER,
@@ -421,6 +432,8 @@ struct interface {
 	uint8_t pref64_length;
 	uint8_t pref64_plc;
 	uint32_t pref64_prefix[3];
+	struct odhcpd_ra_route *ra_static_routes;
+	size_t ra_static_routes_cnt;
 	bool no_dynamic_dhcp;
 	bool have_link_local;
 	uint8_t pio_filter_length;

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -439,7 +439,7 @@ struct interface {
 	uint8_t pio_filter_length;
 	struct in6_addr pio_filter_addr;
 	int default_router;
-	int route_preference;
+	int8_t route_preference;
 	uint32_t ra_maxinterval;
 	uint32_t ra_mininterval;
 	uint32_t ra_lifetime;

--- a/src/router.c
+++ b/src/router.c
@@ -622,6 +622,29 @@ static void router_stale_ra_pio(struct interface *iface,
 	     pio->length);
 }
 
+/* Converts an odhcpd RA route to a route info option */
+static void router_convert_ra_route_to_route_info(const struct odhcpd_ra_route *r,
+						  struct nd_opt_route_info *ri)
+{
+	ri->type = ND_OPT_ROUTE_INFO;
+	ri->len = sizeof(*ri) / 8;
+	ri->prefix_len = r->prefix.len;
+
+	/* Set flags */
+	ri->flags = 0;
+	if (r->preference < 0) {
+		ri->flags |= ND_RA_PREF_LOW;
+	} else if (r->preference > 0) {
+		ri->flags |= ND_RA_PREF_HIGH;
+	}
+
+	ri->lifetime = htonl(r->lifetime);
+	ri->addr[0] = r->prefix.addr.s6_addr32[0];
+	ri->addr[1] = r->prefix.addr.s6_addr32[1];
+	ri->addr[2] = r->prefix.addr.s6_addr32[2];
+	ri->addr[3] = r->prefix.addr.s6_addr32[3];
+}
+
 /* Router Advert server mode */
 static int send_router_advert(struct interface *iface, const struct in6_addr *from)
 {
@@ -1005,54 +1028,65 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	 *           WAN interface.
 	 */
 	if (valid_addr_cnt > 0) {
-		routes = alloca(valid_addr_cnt * sizeof(*routes));
-		memset(routes, 0, valid_addr_cnt * sizeof(*routes));
+		size_t route_info_cnt = valid_addr_cnt + iface->ra_static_routes_cnt;
+		routes = alloca(route_info_cnt * sizeof(*routes));
+		memset(routes, 0, route_info_cnt * sizeof(*routes));
+
+		for (size_t i = 0; i < valid_addr_cnt; ++i) {
+			struct odhcpd_ipaddr *addr = &addrs[i];
+			uint32_t valid_lt;
+
+			if (addr->dprefix_len >= 64 || addr->dprefix_len == 0 ||
+			    addr->valid_lt <= (uint32_t)now) {
+				debug("Address %s (dprefix %d, valid-lifetime %u) not suitable as RA route on %s",
+				      inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
+				      addr->dprefix_len, addr->valid_lt, iface->name);
+				continue;
+			}
+
+			if (ADDR_MATCH_PIO_FILTER(addr, iface)) {
+				debug("Address %s filtered out as RA route on %s",
+				      inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
+				      iface->name);
+				continue;
+			}
+
+			if (addr->dprefix_len > 32) {
+				addr->addr.in6.s6_addr32[1] &= htonl(~((1U << (64 - addr->dprefix_len)) - 1));
+			} else if (addr->dprefix_len <= 32) {
+				addr->addr.in6.s6_addr32[0] &= htonl(~((1U << (32 - addr->dprefix_len)) - 1));
+				addr->addr.in6.s6_addr32[1] = 0;
+			}
+
+			routes[routes_cnt].type = ND_OPT_ROUTE_INFO;
+			routes[routes_cnt].len = sizeof(*routes) / 8;
+			routes[routes_cnt].prefix_len = addr->dprefix_len;
+			routes[routes_cnt].flags = 0;
+			if (iface->route_preference < 0)
+				routes[routes_cnt].flags |= ND_RA_PREF_LOW;
+			else if (iface->route_preference > 0)
+				routes[routes_cnt].flags |= ND_RA_PREF_HIGH;
+
+			valid_lt = TIME_LEFT(addr->valid_lt, now);
+			if (iface->max_valid_lifetime && valid_lt > iface->max_valid_lifetime)
+				valid_lt = iface->max_valid_lifetime;
+			routes[routes_cnt].lifetime = htonl(valid_lt);
+			routes[routes_cnt].addr[0] = addr->addr.in6.s6_addr32[0];
+			routes[routes_cnt].addr[1] = addr->addr.in6.s6_addr32[1];
+			routes[routes_cnt].addr[2] = 0;
+			routes[routes_cnt].addr[3] = 0;
+
+			routes_cnt++;
+		}
+
+		/* Static RA routes */
+		for (size_t i = 0; i < iface->ra_static_routes_cnt; ++i) {
+			router_convert_ra_route_to_route_info(&iface->ra_static_routes[i],
+							      &routes[routes_cnt]);
+			routes_cnt++;
+		}
 	}
-	for (size_t i = 0; i < valid_addr_cnt; ++i) {
-		struct odhcpd_ipaddr *addr = &addrs[i];
-		uint32_t valid_lt;
 
-		if (addr->dprefix_len >= 64 || addr->dprefix_len == 0 || addr->valid_lt <= (uint32_t)now) {
-			debug("Address %s (dprefix %d, valid-lifetime %u) not suitable as RA route on %s",
-			      inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
-			      addr->dprefix_len, addr->valid_lt, iface->name);
-			continue;
-		}
-
-		if (ADDR_MATCH_PIO_FILTER(addr, iface)) {
-			debug("Address %s filtered out as RA route on %s",
-			      inet_ntop(AF_INET6, &addr->addr.in6, buf, sizeof(buf)),
-			      iface->name);
-			continue;
-		}
-
-		if (addr->dprefix_len > 32) {
-			addr->addr.in6.s6_addr32[1] &= htonl(~((1U << (64 - addr->dprefix_len)) - 1));
-		} else if (addr->dprefix_len <= 32) {
-			addr->addr.in6.s6_addr32[0] &= htonl(~((1U << (32 - addr->dprefix_len)) - 1));
-			addr->addr.in6.s6_addr32[1] = 0;
-		}
-
-		routes[routes_cnt].type = ND_OPT_ROUTE_INFO;
-		routes[routes_cnt].len = sizeof(*routes) / 8;
-		routes[routes_cnt].prefix_len = addr->dprefix_len;
-		routes[routes_cnt].flags = 0;
-		if (iface->route_preference < 0)
-			routes[routes_cnt].flags |= ND_RA_PREF_LOW;
-		else if (iface->route_preference > 0)
-			routes[routes_cnt].flags |= ND_RA_PREF_HIGH;
-
-		valid_lt = TIME_LEFT(addr->valid_lt, now);
-		if (iface->max_valid_lifetime && valid_lt > iface->max_valid_lifetime)
-			valid_lt = iface->max_valid_lifetime;
-		routes[routes_cnt].lifetime = htonl(valid_lt);
-		routes[routes_cnt].addr[0] = addr->addr.in6.s6_addr32[0];
-		routes[routes_cnt].addr[1] = addr->addr.in6.s6_addr32[1];
-		routes[routes_cnt].addr[2] = 0;
-		routes[routes_cnt].addr[3] = 0;
-
-		routes_cnt++;
-	}
 	iov[IOV_RA_ROUTES].iov_base = routes;
 	iov[IOV_RA_ROUTES].iov_len = routes_cnt * sizeof(*routes);
 


### PR DESCRIPTION
Introduces a new configuration section `ra_route` for adding custom route(s) in route advertisement (RA) messages.

This is useful when, for example, end devices are given only ULA IPv6 addresses (e.g. from `fc00:0:100::/48`), but one still needs inter-subnet communication to e.g. `fc00:0:200::/48`. Currently, this isn't possible without a static route on each end device, as the odhcpd server doesn't present itself as a default router and no route information is provided other than the on-link local ULA subnet (`fc00:0:100::/48`). Even when odhcpd provides a default route, route customization may be useful in a multi-homed setup to set higher or lower route preferences and enforce different routing behavior (see [RFC4191](https://datatracker.ietf.org/doc/html/rfc4191)).

The new configuration section `ra_route` allows advertising arbitrary routes to end devices, enabling correct routing even when no default route (or public IPv6 prefix) is available.

The configuration section includes four attributes:

| Option	| Type		| Default		| Description |
| :------------ | :------------ | :-------------------- | :---------- |
| prefix	| string	| (none)		| Target IPv6 route prefix, e.g. `2000:abc::/48`. |
| interface	| list		| (none)		| List of interfaces to advertise this route on. If no interface is provided, the route is advertised on all interfaces. |
| preference	| string	| `ra_preference`	| Route preference [medium\|high\|low]. By default interface-specific `ra_preference` value is used. |
| lifetime	| string	| `ra_lifetime`	| Value to be placed in the Route Lifetime field of the Route Information. Implicitly clamped to the interval of sending unsolicited RA (`ra_maxinterval`) as a minimum value. Expected format follows `leasetime`, e.g. 60m, 2h, 3d, 1w. |

**Config example:**

```
# Route advertised only to the `lan` and `guest_wifi` interfaces
config ra_route 'route_branch1'
	option prefix 'fc00:10::/32'
	list interface 'lan'
	list interface 'guest_wifi'
	option preference 'high'
	option lifetime '2h'

# Route advertised to all odhcpd interfaces
config ra_route 'route_branch2'
	option prefix 'fc00:20::/32'
	option preference 'low'
	option lifetime 'infinite'

# Minimal route configuration, defaults are inherited from interfaces
config ra_route 'route_branch3'
	option prefix 'fc00:30::/32'
```

> [!NOTE]
> This patch is a rework of my PR: https://github.com/openwrt/odhcpd/pull/224
>
> The previous implementation used attributes on both global and per-interface basis to configure the static routes. This meant that per-route preference and lifetime couldn't be set, and, most importantly, the original PR didn't take [RFC4191](https://datatracker.ietf.org/doc/html/rfc4191) into account, allowing configuration of static routes only when a default route wasn't present. @systemcrash and I agreed on this redesign (see the discussion of the original PR).

Fixes: https://github.com/openwrt/odhcpd/issues/74 and possibly helps with https://github.com/openwrt/odhcpd/issues/152