### PR TITLE
config: scan dnsmasq instances for interfaces.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2063,14 +2063,21 @@ void odhcpd_reload(void)
 				set_interface(s);
 		}
 
-		/* 3. Static lease cfgs */
+		/* 3. dnsmasq instances */
+		uci_foreach_element(&dhcp->sections, e) {
+			struct uci_section *s = uci_to_section(e);
+			if (!strcmp(s->type, "dnsmasq"))
+				set_interface(s);
+		}
+
+		/* 4. Static lease cfgs */
 		uci_foreach_element(&dhcp->sections, e) {
 			struct uci_section* s = uci_to_section(e);
 			if (!strcmp(s->type, "host"))
 				set_lease_cfg_from_uci(s);
 		}
 
-		/* 4. IPv6 PxE */
+		/* 5. IPv6 PxE */
 		ipv6_pxe_clear();
 		uci_foreach_element(&dhcp->sections, e) {
 			struct uci_section* s = uci_to_section(e);
@@ -2085,7 +2092,7 @@ void odhcpd_reload(void)
 	if (config.enable_tz && !uci_load(uci, uci_system_path, &system)) {
 		struct uci_element *e;
 
-		/* 5. System settings */
+		/* 6. System settings */
 		uci_foreach_element(&system->sections, e) {
 			struct uci_section *s = uci_to_section(e);
 			if (!strcmp(s->type, "system"))


### PR DESCRIPTION
When using multiple dnsmasq instances, odhcpd does not detect the extra interfaces and only provide ipv6 on the main instance.

dnsmasq needs to be also scanned for interfaces.

Luci generate multiple dnsmasq instances the following way:

```
config dnsmasq
        list interface 'lan'
...

config dhcp 'lan'
        option interface 'lan'
        option ra 'server'
        option dhcpv6 'server'
...

config dnsmasq 'guest'
        list interface 'guest'
        option ra 'server'
        option dhcpv6 'server'
...
```