### PR TITLE
Harden DHCPv6/DHCPv4/NDP packet parsing against malformed input

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1331,8 +1331,17 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	}
 
 	if ((c = tb[IFACE_ATTR_CAPTIVE_PORTAL_URI])) {
-		iface->captive_portal_uri = strdup(blobmsg_get_string(c));
-		iface->captive_portal_uri_len = strlen(iface->captive_portal_uri);
+		char *uri = strdup(blobmsg_get_string(c));
+
+		if (!uri) {
+			error("Out of memory parsing %s for interface '%s'",
+			      iface_attrs[IFACE_ATTR_CAPTIVE_PORTAL_URI].name,
+			      iface->name);
+			goto err;
+		}
+
+		iface->captive_portal_uri = uri;
+		iface->captive_portal_uri_len = strlen(uri);
 		if (iface->captive_portal_uri_len > UINT8_MAX) {
 			warn("RFC8910 captive portal URI > %d characters for interface '%s': option via DHCPv4 not possible",
 				UINT8_MAX,

--- a/src/config.c
+++ b/src/config.c
@@ -2048,7 +2048,10 @@ static int ipv6_pxe_from_uci(struct uci_section* s)
 	if (tb[IPV6_PXE_ARCH])
 		arch = blobmsg_get_u32(tb[IPV6_PXE_ARCH]);
 
-	return ipv6_pxe_entry_new(arch, url) ? -1 : 0;
+	/* ipv6_pxe_entry_new() returns the new entry on success and NULL on
+	 * allocation failure. Mirror that into the int return code the rest
+	 * of the module uses: success -> 0, failure -> -1. */
+	return ipv6_pxe_entry_new(arch, url) ? 0 : -1;
 }
 
 void odhcpd_reload(void)

--- a/src/config.c
+++ b/src/config.c
@@ -956,6 +956,11 @@ static int parse_dnr_str(char *str, struct interface *iface)
 					goto err;
 				}
 
+				if (svc_val_len >= DNR_SVC_MAX) {
+					error("Too many keys for SvcParam 'mandatory'");
+					goto err;
+				}
+
 				mkeys[svc_val_len++] = ntohs(mkey);
 			}
 

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -129,7 +129,12 @@ static const char *dhcpv4_msg_to_string(uint8_t req_msg)
 		[DHCPV4_MSG_TLS]		= "DHCPV4_MSG_TLS",
 	};
 
-	if (req_msg >= ARRAY_SIZE(dhcpv4_msg_names))
+	/* Designated initializers leave unspecified slots NULL (e.g. index 0,
+	 * which is not a valid DHCP message type but is a valid uint8_t). The
+	 * return value goes straight into %s format strings, so make sure we
+	 * never hand the caller a NULL pointer.
+	 */
+	if (req_msg >= ARRAY_SIZE(dhcpv4_msg_names) || !dhcpv4_msg_names[req_msg])
 		return "UNKNOWN";
 	return dhcpv4_msg_names[req_msg];
 }

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -285,13 +285,13 @@ static void dhcpv4_fr_send(struct dhcpv4_lease *lease)
 
 		error("Failed to send %s to %s - %s: %m", dhcpv4_msg_to_string(fr_msg.data),
 		      odhcpd_print_mac(lease->hwaddr, sizeof(lease->hwaddr)),
-		      inet_ntop(AF_INET, &dest, ipv4_str, sizeof(ipv4_str)));
+		      inet_ntop(AF_INET, &dest.sin_addr, ipv4_str, sizeof(ipv4_str)));
 	} else {
 		char ipv4_str[INET_ADDRSTRLEN];
 
 		debug("Sent %s to %s - %s", dhcpv4_msg_to_string(fr_msg.data),
 		      odhcpd_print_mac(lease->hwaddr, sizeof(lease->hwaddr)),
-		      inet_ntop(AF_INET, &dest, ipv4_str, sizeof(ipv4_str)));
+		      inet_ntop(AF_INET, &dest.sin_addr, ipv4_str, sizeof(ipv4_str)));
 	}
 }
 

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -753,7 +753,11 @@ static void dhcpv4_set_dest_addr(const struct interface *iface,
 
 			memcpy(arp.arp_ha.sa_data, req->chaddr, 6);
 			memcpy(&arp.arp_pa, dest, sizeof(arp.arp_pa));
-			memcpy(arp.arp_dev, iface->ifname, sizeof(arp.arp_dev));
+			/* arp_dev is a 16-byte fixed buffer; strdup'd ifname is
+			 * typically shorter than that, so memcpy()ing the full
+			 * field length reads past the allocation. Match the
+			 * strncpy pattern used elsewhere for ifr_name. */
+			strncpy(arp.arp_dev, iface->ifname, sizeof(arp.arp_dev) - 1);
 
 			if (ioctl(iface->dhcpv4_event.uloop.fd, SIOCSARP, &arp) < 0)
 				error("ioctl(SIOCSARP): %m");

--- a/src/dhcpv4.h
+++ b/src/dhcpv4.h
@@ -182,10 +182,19 @@ struct dhcpv4_dnr {
 };
 
 
+/* RFC2132 §3.1/§3.2 (orig. RFC1497): the Pad (0) and End (255) options are
+ * 1 octet long and have no length byte. Every other DHCPv4 option is
+ * { code, len, data[len] }. Treat Pad as a 1-byte no-op, End as loop
+ * termination, and reject any other option whose declared length runs past
+ * the buffer.
+ */
 #define dhcpv4_for_each_option(start, end, opt)\
-	for (opt = (struct dhcpv4_option*)(start); \
-		&opt[1] <= (struct dhcpv4_option*)(end) && \
-			&opt->data[opt->len] <= (end); \
-		opt = (struct dhcpv4_option*)&opt->data[opt->len])
+	for (uint8_t *_o = (uint8_t *)(start); \
+		_o < (uint8_t *)(end) && \
+		(opt = (struct dhcpv4_option *)_o)->code != DHCPV4_OPT_END && \
+		(opt->code == DHCPV4_OPT_PAD || \
+		 (_o + 2 <= (uint8_t *)(end) && \
+		  _o + 2 + opt->len <= (uint8_t *)(end))); \
+		_o += (opt->code == DHCPV4_OPT_PAD) ? 1 : 2 + opt->len)
 
 #endif /* _DHCPV4_H_ */

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -813,7 +813,7 @@ static size_t build_ia(uint8_t *buf, size_t buflen, uint16_t status,
 					};
 
 					if (buflen < ia_len + sizeof(o_ia_a))
-						continue;
+						return 0;
 
 					memcpy(buf + ia_len, &o_ia_a, sizeof(o_ia_a));
 					ia_len += sizeof(o_ia_a);

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1026,6 +1026,14 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 		if (!is_pd && !is_na)
 			continue;
 
+		/* RFC8415 §21.4 / §21.21: an IA_NA/IA_PD option carries at
+		 * least 12 bytes of fixed payload (iaid + t1 + t2) before any
+		 * sub-options. Without this guard, a crafted option with
+		 * olen < 12 lets us read ia->iaid/t1/t2 out of bounds (the
+		 * iterator only enforces odata + olen <= end). */
+		if (olen < sizeof(struct dhcpv6_ia_hdr) - DHCPV6_OPT_HDR_SIZE)
+			continue;
+
 		struct dhcpv6_ia_hdr *ia = (struct dhcpv6_ia_hdr*)&odata[-DHCPV6_OPT_HDR_SIZE];
 		size_t ia_response_len = 0;
 		uint8_t reqlen = (is_pd) ? 62 : 128;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -346,8 +346,14 @@ static bool assign_pd(struct interface *iface, struct dhcpv6_lease *assign)
 	if (iface->addr6_len < 1)
 		return false;
 
-	/* Try honoring the hint first */
-	uint32_t current = 1, asize = (1 << (64 - assign->length)) - 1;
+	/* Try honoring the hint first.
+	 *
+	 * Subnet-id slots per delegated prefix = 2^(64 - length); the literal
+	 * 1 is plain int, so shifting it by 32-63 bits is undefined behaviour
+	 * for short prefix lengths (the user can drive this via
+	 * dhcpv6_pd_min_len). Compute the shift in uint64_t and truncate.
+	 */
+	uint32_t current = 1, asize = (uint32_t)((1ULL << (64 - assign->length)) - 1);
 	if (assign->assigned_subnet_id) {
 		list_for_each_entry(c, &iface->ia_assignments, head) {
 			if (c->flags & OAF_DHCPV6_NA)
@@ -362,7 +368,7 @@ static bool assign_pd(struct interface *iface, struct dhcpv6_lease *assign)
 				return true;
 			}
 
-			current = (c->assigned_subnet_id + (1 << (64 - c->length)));
+			current = (uint32_t)(c->assigned_subnet_id + (1ULL << (64 - c->length)));
 		}
 	}
 
@@ -384,7 +390,7 @@ static bool assign_pd(struct interface *iface, struct dhcpv6_lease *assign)
 			return true;
 		}
 
-		current = (c->assigned_subnet_id + (1 << (64 - c->length)));
+		current = (uint32_t)(c->assigned_subnet_id + (1ULL << (64 - c->length)));
 	}
 
 	return false;

--- a/src/dhcpv6-pxe.c
+++ b/src/dhcpv6-pxe.c
@@ -32,6 +32,11 @@ const struct ipv6_pxe_entry* ipv6_pxe_entry_new(uint32_t arch, const char* url) 
 	ipe->bootfile_url.type = htons(DHCPV6_OPT_BOOTFILE_URL);
 
 	if (arch == 0xFFFFFFFF) {
+		/* The "default" entry lives outside ipv6_pxe_list; if config
+		 * already supplied one (e.g. two boot6 sections without an
+		 * arch), free the previous one before replacing it, otherwise
+		 * it would leak until ipv6_pxe_clear() runs. */
+		free(ipv6_pxe_default);
 		ipv6_pxe_default = ipe;
 	}
 	else {

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -251,10 +251,19 @@ static void update_nested_message(uint8_t *data, size_t len, unsigned depth, ssi
 	uint8_t *odata;
 	dhcpv6_for_each_option(hdr->options, data + len, otype, olen, odata) {
 		if (otype == DHCPV6_OPT_RELAY_MSG) {
-			olen += pdiff;
-			odata[-2] = (olen >> 8) & 0xff;
-			odata[-1] = olen & 0xff;
-			update_nested_message(odata, olen - pdiff, depth + 1, pdiff);
+			ssize_t newlen = (ssize_t)olen + pdiff;
+
+			/* olen was validated to lie within the buffer by the option
+			 * iterator. Reject a pdiff that would make the rewritten
+			 * RELAY_MSG length wrap the 16-bit field, which would also feed
+			 * a bogus length into the recursion below and walk options past
+			 * the end of the (untrusted) packet buffer. */
+			if (newlen < 0 || newlen > UINT16_MAX)
+				return;
+
+			odata[-2] = (newlen >> 8) & 0xff;
+			odata[-1] = newlen & 0xff;
+			update_nested_message(odata, olen, depth + 1, pdiff);
 			return;
 		}
 	}

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -533,7 +533,11 @@ static void handle_client_request(void *addr, void *data, size_t len,
 
 	uint16_t otype, olen;
 	uint8_t *odata;
-	uint16_t *reqopts = NULL;
+	/* OPTION_ORO payload is an array of uint16_t but the underlying buffer
+	 * isn't guaranteed to be 2-byte aligned (it's at an arbitrary offset
+	 * inside the packed wire packet), so keep it as a byte pointer and
+	 * memcpy each value out rather than casting to uint16_t *. */
+	uint8_t *reqopts = NULL;
 	size_t reqopts_cnt = 0;
 
 	/* FIXME: this should be merged with the second loop further down */
@@ -541,14 +545,17 @@ static void handle_client_request(void *addr, void *data, size_t len,
 		/* Requested options, array of uint16_t, RFC 8415 §21.7 */
 		if (otype == DHCPV6_OPT_ORO) {
 			reqopts_cnt = olen / sizeof(uint16_t);
-			reqopts = (uint16_t *)odata;
+			reqopts = odata;
 			break;
 		}
 	}
 
 	/* Requested options */
 	for (size_t i = 0; i < reqopts_cnt; i++) {
-		uint16_t opt = ntohs(reqopts[i]);
+		uint16_t opt;
+
+		memcpy(&opt, &reqopts[i * sizeof(uint16_t)], sizeof(opt));
+		opt = ntohs(opt);
 
 		switch (opt) {
 		case DHCPV6_OPT_SNTP_SERVERS:
@@ -704,8 +711,12 @@ static void handle_client_request(void *addr, void *data, size_t len,
 			iov[IOV_RAPID_COMMIT].iov_len = sizeof(rapid_commit);
 			o_rapid_commit = true;
 		} else if (otype == DHCPV6_OPT_ORO) {
-			for (int i=0; i < olen/2; i++) {
-				uint16_t option = ntohs(((uint16_t *)odata)[i]);
+			for (int i = 0; i < olen / 2; i++) {
+				uint16_t option;
+
+				/* odata is not guaranteed to be uint16-aligned. */
+				memcpy(&option, &odata[i * 2], sizeof(option));
+				option = ntohs(option);
 
 				switch (option) {
 #ifdef DHCPV4_SUPPORT

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -716,10 +716,10 @@ static void handle_client_request(void *addr, void *data, size_t len,
 		}
 	}
 
-	if (dest.serverid_length == clientid.len && 
-	    !memcmp(clientid.buf, dest.serverid_buf, dest.serverid_length)) {
+	if (dest.serverid_length == clientid.len &&
+	    !memcmp(clientid.buf, dest.serverid_buf, ntohs(dest.serverid_length))) {
 		/* Bail if we are in a network loop where we talk with ourself */
-		return;		
+		return;
 	}
 
 	if (!IN6_IS_ADDR_MULTICAST((struct in6_addr *)dest_addr) && iov[IOV_NESTED].iov_len == 0 &&

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -974,6 +974,14 @@ static void relay_client_request(struct sockaddr_in6 *source,
 	struct odhcpd_ipaddr *ip;
 	struct sockaddr_in6 s;
 
+	/* A bare UDP socket can deliver a zero/short payload; the relay-reply
+	 * path (relay_server_response) checks this but the client-side relay
+	 * did not. relay_client_request() reads h->msg_type, plus h->hop_count
+	 * for a RELAY_FORW, out of the relay header and forwards the rest
+	 * verbatim, so require at least those two leading header bytes. */
+	if (len < offsetof(struct dhcpv6_relay_header, link_address))
+		return;
+
 	switch (h->msg_type) {
 	/* Valid message types from clients */
 	case DHCPV6_MSG_SOLICIT:

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -192,7 +192,7 @@ enum {
 	IOV_TOTAL
 };
 
-static void handle_nested_message(uint8_t *data, size_t len,
+static void handle_nested_message(uint8_t *data, size_t len, unsigned depth,
 				  struct dhcpv6_client_header **c_hdr, uint8_t **opts,
 				  uint8_t **end, struct iovec iov[IOV_TOTAL])
 {
@@ -216,25 +216,36 @@ static void handle_nested_message(uint8_t *data, size_t len,
 		return;
 	}
 
+	/* Each nested Relay-Forward is one relay hop; RFC8415 bounds a relay
+	 * chain via HOP_COUNT_LIMIT (defined in §7.6, enforced in §19.1.2),
+	 * so refuse to recurse deeper and avoid stack exhaustion on crafted
+	 * relay loops. */
+	if (depth >= DHCPV6_HOP_COUNT_LIMIT)
+		return;
+
 	dhcpv6_for_each_option(r_hdr->options, data + len, otype, olen, odata) {
 		if (otype == DHCPV6_OPT_RELAY_MSG) {
 			iov[IOV_RELAY_MSG].iov_base = odata + olen;
 			iov[IOV_RELAY_MSG].iov_len = (((uint8_t *)iov[IOV_NESTED].iov_base) +
 					iov[IOV_NESTED].iov_len) - (odata + olen);
-			handle_nested_message(odata, olen, c_hdr, opts, end, iov);
+			handle_nested_message(odata, olen, depth + 1, c_hdr, opts, end, iov);
 			return;
 		}
 	}
 }
 
 
-static void update_nested_message(uint8_t *data, size_t len, ssize_t pdiff)
+static void update_nested_message(uint8_t *data, size_t len, unsigned depth, ssize_t pdiff)
 {
 	struct dhcpv6_relay_header *hdr = (struct dhcpv6_relay_header*)data;
 	if (hdr->msg_type != DHCPV6_MSG_RELAY_FORW)
 		return;
 
 	hdr->msg_type = DHCPV6_MSG_RELAY_REPL;
+
+	/* Bound recursion to mirror handle_nested_message(). */
+	if (depth >= DHCPV6_HOP_COUNT_LIMIT)
+		return;
 
 	uint16_t otype, olen;
 	uint8_t *odata;
@@ -243,7 +254,7 @@ static void update_nested_message(uint8_t *data, size_t len, ssize_t pdiff)
 			olen += pdiff;
 			odata[-2] = (olen >> 8) & 0xff;
 			odata[-1] = olen & 0xff;
-			update_nested_message(odata, olen - pdiff, pdiff);
+			update_nested_message(odata, olen - pdiff, depth + 1, pdiff);
 			return;
 		}
 	}
@@ -657,7 +668,7 @@ static void handle_client_request(void *addr, void *data, size_t len,
 	};
 
 	if (hdr->msg_type == DHCPV6_MSG_RELAY_FORW)
-		handle_nested_message(data, len, &hdr, &opts, &opts_end, iov);
+		handle_nested_message(data, len, 0, &hdr, &opts, &opts_end, iov);
 
 	if (!IN6_IS_ADDR_MULTICAST((struct in6_addr *)dest_addr) && iov[IOV_NESTED].iov_len == 0 &&
 	    (hdr->msg_type == DHCPV6_MSG_SOLICIT || hdr->msg_type == DHCPV6_MSG_CONFIRM ||
@@ -780,7 +791,7 @@ static void handle_client_request(void *addr, void *data, size_t len,
 	}
 
 	if (iov[IOV_NESTED].iov_len > 0) /* Update length */
-		update_nested_message(data, len, iov[IOV_DEST].iov_len + iov[IOV_MAXRT].iov_len +
+		update_nested_message(data, len, 0, iov[IOV_DEST].iov_len + iov[IOV_MAXRT].iov_len +
 				      iov[IOV_RAPID_COMMIT].iov_len + iov[IOV_DNS].iov_len +
 				      iov[IOV_DNS_ADDR].iov_len + iov[IOV_SEARCH].iov_len +
 				      iov[IOV_SEARCH_DOMAIN].iov_len + iov[IOV_PDBUF].iov_len +

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -318,6 +318,19 @@ static ssize_t dhcpv6_4o6_query(uint8_t *buf, size_t buflen,
 		return -1;
 	}
 
+	/* dhcpv4_handle_msg() reads the full BOOTP fixed header (op, htype,
+	 * hlen, hops, xid, secs, flags, ciaddr, yiaddr, siaddr, giaddr,
+	 * chaddr, sname, file, cookie = offsetof(options) bytes) before
+	 * parsing options. The normal DHCPv4 socket path enforces this via a
+	 * BPF filter, but the DHCPv4-over-DHCPv6 path bypasses that filter,
+	 * so validate the length here to prevent an out-of-bounds read on a
+	 * truncated DHCPV4_MSG option. RFC7341 §7.1 defines the DHCPv4 Message
+	 * option but mandates no minimum length, so this floor is ours. */
+	if (msgv4_len < offsetof(struct dhcpv4_message, options)) {
+		error("4o6: encapsulated DHCPv4 message too short (%u)", msgv4_len);
+		return -1;
+	}
+
 	// Dummy IPv4 address
 	memset(&addrv4, 0, sizeof(addrv4));
 	addrv4.sin_family = AF_INET;

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -745,8 +745,14 @@ static void handle_client_request(void *addr, void *data, size_t len,
 					break;
 				}
 			}
-		} else if (otype == DHCPV6_OPT_CLIENT_ARCH) {
-			uint16_t arch_code = ntohs(((uint16_t*)odata)[0]);
+		} else if (otype == DHCPV6_OPT_CLIENT_ARCH && olen >= sizeof(uint16_t)) {
+			uint16_t arch_code;
+
+			/* odata is not guaranteed to be uint16-aligned, and
+			 * RFC5970 §3.3 mandates olen be a multiple of 2 with
+			 * at least one architecture entry — read defensively. */
+			memcpy(&arch_code, odata, sizeof(arch_code));
+			arch_code = ntohs(arch_code);
 			ipv6_pxe_serve_boot_url(arch_code, &iov[IOV_BOOTFILE_URL]);
 		}
 	}

--- a/src/ndp.c
+++ b/src/ndp.c
@@ -382,6 +382,15 @@ static void handle_solicit(void *addr, void *data, size_t len,
 	if (len < sizeof(*ip6) + sizeof(*req))
 		return; // Invalid total length
 
+	/* RFC4861 §7.1.1: a Neighbor Solicitation MUST be silently discarded
+	 * if the IP Hop Limit field is not 255 or the ICMP Code is non-zero.
+	 * The hop-limit check is what protects against off-link attackers
+	 * forging NS / DAD messages, so it must not be skipped. Because the
+	 * NDP socket is AF_PACKET (not a kernel-managed ICMPv6 socket), we
+	 * have to enforce it ourselves. */
+	if (ip6->ip6_hlim != 255 || req->nd_ns_hdr.icmp6_code != 0)
+		return;
+
 	if (IN6_IS_ADDR_LINKLOCAL(&req->nd_ns_target) ||
 			IN6_IS_ADDR_LOOPBACK(&req->nd_ns_target) ||
 			IN6_IS_ADDR_MULTICAST(&req->nd_ns_target))

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -587,8 +587,14 @@ static int cb_addr_valid(struct nl_msg *msg, void *arg)
 	memset(&oaddrs[ctxt->ret], 0, sizeof(oaddrs[ctxt->ret]));
 	oaddrs[ctxt->ret].prefix_len = ifa->ifa_prefixlen;
 
-	if (ifa->ifa_family == AF_INET)
-		oaddrs[ctxt->ret].netmask = htonl(~((1U << (32 - ifa->ifa_prefixlen)) - 1));
+	if (ifa->ifa_family == AF_INET) {
+		/* ifa_prefixlen is 0..32. A /0 prefix turns "32 - prefix" into a
+		 * 32-bit shift on a 32-bit type, which is undefined behaviour;
+		 * compute the host mask in 64-bit and truncate so /0 yields a
+		 * zero netmask as expected. */
+		uint32_t host_bits = (uint32_t)((1ULL << (32 - ifa->ifa_prefixlen)) - 1);
+		oaddrs[ctxt->ret].netmask = htonl(~host_bits);
+	}
 
 	nla_memcpy(&oaddrs[ctxt->ret].addr, nla_addr, sizeof(oaddrs[ctxt->ret].addr));
 

--- a/src/router.c
+++ b/src/router.c
@@ -902,6 +902,12 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 			dns_addrs6_cnt = 1;
 		}
 
+		/* The RDNSS len field is a uint8_t counting 8-byte units, so it
+		 * holds at most 127 addresses (1 + 2*127 == 255); drop any extra
+		 * so the on-wire length stays consistent with the bytes sent. */
+		if (dns_addrs6_cnt > 127)
+			dns_addrs6_cnt = 127;
+
 		if (dns_addrs6_cnt) {
 			dns_sz = sizeof(*dns) + dns_addrs6_cnt * sizeof(*dns_addrs6);
 
@@ -917,7 +923,11 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	iov[IOV_RA_DNS].iov_len = dns_sz;
 
 	/* DNS Search List aka DNSSL; RFC8106, §5.2 */
-	if (iface->ra_dns && iface->dns_search_len > 0) {
+	/* The DNSSL len field is a uint8_t counting 8-byte units, so the whole
+	 * option must fit in UINT8_MAX*8 bytes; skip it otherwise rather than
+	 * emit an option whose length field does not match its real size. */
+	if (iface->ra_dns && iface->dns_search_len > 0 &&
+	    sizeof(*search) + ((iface->dns_search_len + 7) & ~7) <= UINT8_MAX * 8) {
 		search_sz = sizeof(*search) + ((iface->dns_search_len + 7) & ~7);
 		search = alloca(search_sz);
 		memset(search, 0, search_sz);

--- a/src/router.c
+++ b/src/router.c
@@ -1174,7 +1174,7 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 	/* Rewrite options */
 	uint8_t *end = data + len;
 	uint8_t *mac_ptr = NULL;
-	struct in6_addr *dns_addrs6 = NULL;
+	struct in6_addr *dns_addrs6 = NULL, *dns_addrs6_orig = NULL;
 	size_t dns_addrs6_cnt = 0;
 	// MTU option
 	struct nd_opt_mtu *mtu_opt = NULL;
@@ -1247,9 +1247,24 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 	all_nodes.sin6_family = AF_INET6;
 	inet_pton(AF_INET6, ALL_IPV6_NODES, &all_nodes.sin6_addr);
 
+	/* Preserve the upstream DNS addresses: they are rewritten in place in the
+	 * single shared packet buffer, so without restoring them a later slave
+	 * would inherit a previous slave's rewritten values. */
+	if (dns_addrs6 && dns_addrs6_cnt > 0) {
+		dns_addrs6_orig = alloca(dns_addrs6_cnt * sizeof(*dns_addrs6_orig));
+		memcpy(dns_addrs6_orig, dns_addrs6, dns_addrs6_cnt * sizeof(*dns_addrs6_orig));
+	}
+
 	avl_for_each_element(&interfaces, c, avl) {
 		if (c->ra != MODE_RELAY || c->master)
 			continue;
+
+		/* Restore the upstream DNS addresses and MTU value that a previous
+		 * slave may have rewritten in the shared buffer. */
+		if (dns_addrs6_orig)
+			memcpy(dns_addrs6, dns_addrs6_orig, dns_addrs6_cnt * sizeof(*dns_addrs6));
+		if (mtu_opt)
+			mtu_opt->nd_opt_mtu_mtu = htonl(ingress_mtu_val);
 
 		/* Fixup source hardware address option */
 		if (mac_ptr)

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -361,7 +361,13 @@ static void statefiles_write_host(const char *ipbuf, const char *hostname, struc
 {
 	char exp_dn[DNS_MAX_NAME_LEN];
 
-	if (dn_expand(ctxt->iface->dns_search, ctxt->iface->dns_search + ctxt->iface->dns_search_len,
+	/* Since the DNS search-domain fallback was dropped, dns_search may
+	 * legitimately be NULL on interfaces with no configured domain. Skip
+	 * dn_expand() in that case to avoid pointer arithmetic on NULL and
+	 * libc-specific NULL handling in dn_expand(). */
+	if (ctxt->iface->dns_search && ctxt->iface->dns_search_len > 0 &&
+	    dn_expand(ctxt->iface->dns_search,
+		      ctxt->iface->dns_search + ctxt->iface->dns_search_len,
 		      ctxt->iface->dns_search, exp_dn, sizeof(exp_dn)) > 0)
 		fprintf(ctxt->fp, "%s\t%s.%s\t%s\n", ipbuf, hostname, exp_dn, hostname);
 	else

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -51,11 +51,13 @@ static FILE *statefiles_open_tmp_file(int dirfd)
 		return NULL;
 
 	fd = openat(dirfd, ODHCPD_TMP_FILE, O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
-	if (fd < 0)
-		goto err;
+	if (fd < 0) {
+		error("Failed to create temporary file: %m");
+		return NULL;
+	}
 
 	if (lockf(fd, F_LOCK, 0) < 0)
-		goto err;
+		goto err_del;
 
 	if (ftruncate(fd, 0) < 0)
 		goto err_del;
@@ -67,10 +69,12 @@ static FILE *statefiles_open_tmp_file(int dirfd)
 	return fp;
 
 err_del:
-	unlinkat(dirfd, ODHCPD_TMP_FILE, 0);
-err:
-	close(fd);
+	/* Log before unlinkat()/close() so they don't clobber errno. The
+	 * old code also called close(fd) on the openat-failure path, which
+	 * meant close(-1) overwrote errno with EBADF before %m printed it. */
 	error("Failed to create temporary file: %m");
+	unlinkat(dirfd, ODHCPD_TMP_FILE, 0);
+	close(fd);
 	return NULL;
 }
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -52,7 +52,7 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _o_unused struct ubus_
 				buf = blobmsg_alloc_string_buffer(&b, "duid", DUID_HEXSTRLEN + 1);
 				odhcpd_hexlify(buf, c->duid, c->duid_len);
 				blobmsg_add_string_buffer(&b);
-				blobmsg_add_u32(&b, "iaid", ntohl(c->iaid));
+				blobmsg_add_u32(&b, "iaid", c->iaid);
 			}
 
 			blobmsg_add_string(&b, "hostname", (c->hostname) ? c->hostname : "");


### PR DESCRIPTION
## Summary

A batch of 25 small, self-contained fixes hardening odhcpd against
malformed or malicious DHCPv6/DHCPv4/NDP packets, plus a few related
UB, resource-handling and correctness fixes. Most are reachable from
the network and several are genuine memory-safety issues. Each commit
is one logical fix with a standalone rationale; no behaviour changes
for well-formed traffic except the one ubus correction noted below.

Touches: dhcpv6.c, dhcpv6-ia.c, dhcpv6-pxe.c, dhcpv4.c, dhcpv4.h,
ndp.c, netlink.c, router.c, config.c, statefiles.c, ubus.c.

## Memory safety on network-controlled input

- **dhcpv6: fix OOB stack read in self-loop detection** — `memcmp()`
  was passed a network-byte-order DUID length as its size; on
  little-endian a 14-byte DUID became a ~3.5 KB read off a ~130-byte
  stack buffer. Attacker-reachable.
- **dhcpv6: bound nested relay-forward recursion to HOP_COUNT_LIMIT** —
  deeply nested `OPTION_RELAY_MSG` could drive ~1700-deep recursion and
  exhaust the stack (DoS).
- **dhcpv6: validate rewritten RELAY_MSG length in
  update_nested_message()** — when building a relay-reply the nested
  `OPTION_RELAY_MSG` length is adjusted by `pdiff`; if `olen + pdiff`
  left the 0..65535 range the `uint16_t` wrapped, and the wrapped value
  was both written on the wire and fed to the recursion as its buffer
  size, walking option headers past the end of the (untrusted) receive
  buffer — an OOB read plus a 2-byte OOB write, driven by a crafted
  multi-level Relay-Forward packet. Compute the new length in a signed
  wide type, bail out if it would not fit in 16 bits, and pass the
  already-validated original length to the recursion.
- **dhcpv4: honor Pad/End option encoding** — the iterator treated Pad
  (0)/End (255) as TLVs, letting a crafted request hide later options
  (message type, client-id) from the server.
- **dhcpv6: reject undersized encapsulated DHCPv4 messages on the 4o6
  path** — that path bypasses the BPF length filter the native socket
  relies on, so a short DHCPV4_MSG could read past the buffer.
- **dhcpv6: length-check relay_client_request()** before touching the
  relay header (zero/short UDP datagrams).
- **dhcpv6-ia: validate IA_NA/IA_PD option length** before reading
  iaid/t1/t2.
- **dhcpv6: validate length and fix unaligned read of CLIENT_ARCH**.
- **dhcpv6: use memcpy for ORO option codes** — avoids unaligned u16
  reads (SIGBUS on ARM/MIPS/SPARC).
- **ndp: enforce RFC4861 §7.1.1 hop-limit (255) and ICMP code (0) on
  NS** — the hop-limit check blocks off-link NS/DAD spoofing; AF_PACKET
  gives no kernel L3 validation here.
- **config: bound DNR 'mandatory' SvcParam key count** — the `mandatory`
  SvcParam parser wrote referenced keys into the fixed-size stack array
  `mkeys[DNR_SVC_MAX]` without bounding the count. RFC 9460 forbids
  duplicate keys, but the parser accepted them, so a config repeating a
  present key (e.g. `mandatory=alpn,alpn,…`) wrote past the end of the
  array and smashed the stack. Reachable via UCI config rather than the
  network, but still a stack overflow; reject the entry once
  `DNR_SVC_MAX` keys have been recorded.

## Undefined behaviour

- **dhcpv6-ia: avoid undefined shift in assign_pd()** — `1 << (64-len)`
  with a user-configurable prefix length down to 1.
- **netlink: avoid 32-bit-wide shift** when computing a /0 IPv4 netmask.

## Resource handling and error paths

- **config: guard captive_portal_uri against strdup() failure**
  (`strlen(NULL)`).
- **dhcpv4: never return NULL from dhcpv4_msg_to_string()** (fed into
  `%s`).
- **statefiles: clean up tmpfile error path** — left a stale tmpfile on
  lock failure and logged the wrong errno.
- **dhcpv6-pxe: free previous default boot entry on replacement** (leak).
- **statefiles: skip dn_expand() when no search domain** (NULL pointer
  arithmetic).
- **dhcpv4: strncpy ifname into arpreq** instead of memcpy'ing past the
  strdup'd source.

## Correctness

- **ubus: drop the spurious second ntohl() of the DHCPv4 lease IAID** —
  now matches the `dhcp.lease4` event and the host-order storage.
  ⚠️ **Behavioural change:** the `iaid` reported by
  `ubus call dhcpd ipv4leases` changes on little-endian hosts (the old
  value was byte-swapped/incorrect).
- **config: fix inverted return value of ipv6_pxe_from_uci()** —
  currently harmless (caller ignores it), corrected for future callers.
- **router: restore upstream DNS/MTU between relayed RAs** —
  `forward_router_advertisement()` forwards one shared packet buffer to
  every slave interface in turn. The RDNSS addresses and the MTU option
  were rewritten in place but, unlike the MAC/PIO/RA flags, never
  restored between iterations, so a slave without
  `always_rewrite_dns`/`ra_mtu` could leak a previous slave's DNS
  servers or MTU to its clients. Snapshot the upstream DNS addresses
  before the loop and restore both DNS and MTU at the start of each
  iteration.
- **router: keep RA DNS option lengths within the uint8 length field** —
  the RDNSS and DNSSL option length fields (RFC 8106) are `uint8_t`
  counting 8-byte units, but were computed from the configured DNS
  server count / search-list size without any bound; with ≥128 DNS
  servers `1 + 2*cnt` wraps, while the bytes actually written used the
  full size, so the option length no longer matched its real size and
  clients mis-parse or drop the RA. Cap RDNSS at 127 servers
  (`1 + 2*127 == 255`) and skip DNSSL when it would not fit in a valid
  uint8 length.
- **dhcpv6-ia: signal buffer-full from build_ia() IA_ADDR branch** — in
  the CONFIRM/RELEASE/DECLINE echo path the IA_PREFIX branch returns 0
  (the buffer-full signal) when the next option will not fit, but the
  sibling IA_ADDR branch used `continue`, so the loop fell through to
  writing the IA header and returning a non-zero length and the caller
  put a truncated IA — missing the IA_ADDR(s) that did not fit — on the
  wire. Return 0 from the IA_ADDR branch as well.
- **dhcpv4: pass &dest.sin_addr to inet_ntop() when logging** —
  `dhcpv4_fr_send()` passed `&dest` (a `struct sockaddr_in`) to
  `inet_ntop(AF_INET, …)`, which expects a `struct in_addr`, so the
  FORCERENEW send / send-failure log lines printed the first four bytes
  of the sockaddr instead of the target address.

## How this was found / testing

Found via an AI-assisted code review (Claude Opus); every finding was
verified by hand against the affected code paths and the cited RFCs
(RFC8415, RFC8106, RFC9460, RFC4861, RFC5970, RFC7341, RFC2132).
Commits carry `Assisted-by:` trailers per
Documentation/process/coding-assistants.rst alongside my Signed-off-by.
