### PR TITLE
[25.12]: backport fixes from master

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1328,8 +1328,17 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 	}
 
 	if ((c = tb[IFACE_ATTR_CAPTIVE_PORTAL_URI])) {
-		iface->captive_portal_uri = strdup(blobmsg_get_string(c));
-		iface->captive_portal_uri_len = strlen(iface->captive_portal_uri);
+		char *uri = strdup(blobmsg_get_string(c));
+
+		if (!uri) {
+			error("Out of memory parsing %s for interface '%s'",
+			      iface_attrs[IFACE_ATTR_CAPTIVE_PORTAL_URI].name,
+			      iface->name);
+			goto err;
+		}
+
+		iface->captive_portal_uri = uri;
+		iface->captive_portal_uri_len = strlen(uri);
 		if (iface->captive_portal_uri_len > UINT8_MAX) {
 			warn("RFC8910 captive portal URI > %d characters for interface '%s': option via DHCPv4 not possible",
 				UINT8_MAX,

--- a/src/config.c
+++ b/src/config.c
@@ -953,6 +953,11 @@ static int parse_dnr_str(char *str, struct interface *iface)
 					goto err;
 				}
 
+				if (svc_val_len >= DNR_SVC_MAX) {
+					error("Too many keys for SvcParam 'mandatory'");
+					goto err;
+				}
+
 				mkeys[svc_val_len++] = ntohs(mkey);
 			}
 

--- a/src/config.c
+++ b/src/config.c
@@ -2012,7 +2012,10 @@ static int ipv6_pxe_from_uci(struct uci_section* s)
 	if (tb[IPV6_PXE_ARCH])
 		arch = blobmsg_get_u32(tb[IPV6_PXE_ARCH]);
 
-	return ipv6_pxe_entry_new(arch, url) ? -1 : 0;
+	/* ipv6_pxe_entry_new() returns the new entry on success and NULL on
+	 * allocation failure. Mirror that into the int return code the rest
+	 * of the module uses: success -> 0, failure -> -1. */
+	return ipv6_pxe_entry_new(arch, url) ? 0 : -1;
 }
 
 void odhcpd_reload(void)

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -129,7 +129,12 @@ static const char *dhcpv4_msg_to_string(uint8_t req_msg)
 		[DHCPV4_MSG_TLS]		= "DHCPV4_MSG_TLS",
 	};
 
-	if (req_msg >= ARRAY_SIZE(dhcpv4_msg_names))
+	/* Designated initializers leave unspecified slots NULL (e.g. index 0,
+	 * which is not a valid DHCP message type but is a valid uint8_t). The
+	 * return value goes straight into %s format strings, so make sure we
+	 * never hand the caller a NULL pointer.
+	 */
+	if (req_msg >= ARRAY_SIZE(dhcpv4_msg_names) || !dhcpv4_msg_names[req_msg])
 		return "UNKNOWN";
 	return dhcpv4_msg_names[req_msg];
 }

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -285,13 +285,13 @@ static void dhcpv4_fr_send(struct dhcpv4_lease *lease)
 
 		error("Failed to send %s to %s - %s: %m", dhcpv4_msg_to_string(fr_msg.data),
 		      odhcpd_print_mac(lease->hwaddr, sizeof(lease->hwaddr)),
-		      inet_ntop(AF_INET, &dest, ipv4_str, sizeof(ipv4_str)));
+		      inet_ntop(AF_INET, &dest.sin_addr, ipv4_str, sizeof(ipv4_str)));
 	} else {
 		char ipv4_str[INET_ADDRSTRLEN];
 
 		debug("Sent %s to %s - %s", dhcpv4_msg_to_string(fr_msg.data),
 		      odhcpd_print_mac(lease->hwaddr, sizeof(lease->hwaddr)),
-		      inet_ntop(AF_INET, &dest, ipv4_str, sizeof(ipv4_str)));
+		      inet_ntop(AF_INET, &dest.sin_addr, ipv4_str, sizeof(ipv4_str)));
 	}
 }
 

--- a/src/dhcpv4.c
+++ b/src/dhcpv4.c
@@ -753,7 +753,11 @@ static void dhcpv4_set_dest_addr(const struct interface *iface,
 
 			memcpy(arp.arp_ha.sa_data, req->chaddr, 6);
 			memcpy(&arp.arp_pa, dest, sizeof(arp.arp_pa));
-			memcpy(arp.arp_dev, iface->ifname, sizeof(arp.arp_dev));
+			/* arp_dev is a 16-byte fixed buffer; strdup'd ifname is
+			 * typically shorter than that, so memcpy()ing the full
+			 * field length reads past the allocation. Match the
+			 * strncpy pattern used elsewhere for ifr_name. */
+			strncpy(arp.arp_dev, iface->ifname, sizeof(arp.arp_dev) - 1);
 
 			if (ioctl(iface->dhcpv4_event.uloop.fd, SIOCSARP, &arp) < 0)
 				error("ioctl(SIOCSARP): %m");

--- a/src/dhcpv4.h
+++ b/src/dhcpv4.h
@@ -182,10 +182,19 @@ struct dhcpv4_dnr {
 };
 
 
+/* RFC2132 §3.1/§3.2 (orig. RFC1497): the Pad (0) and End (255) options are
+ * 1 octet long and have no length byte. Every other DHCPv4 option is
+ * { code, len, data[len] }. Treat Pad as a 1-byte no-op, End as loop
+ * termination, and reject any other option whose declared length runs past
+ * the buffer.
+ */
 #define dhcpv4_for_each_option(start, end, opt)\
-	for (opt = (struct dhcpv4_option*)(start); \
-		&opt[1] <= (struct dhcpv4_option*)(end) && \
-			&opt->data[opt->len] <= (end); \
-		opt = (struct dhcpv4_option*)&opt->data[opt->len])
+	for (uint8_t *_o = (uint8_t *)(start); \
+		_o < (uint8_t *)(end) && \
+		(opt = (struct dhcpv4_option *)_o)->code != DHCPV4_OPT_END && \
+		(opt->code == DHCPV4_OPT_PAD || \
+		 (_o + 2 <= (uint8_t *)(end) && \
+		  _o + 2 + opt->len <= (uint8_t *)(end))); \
+		_o += (opt->code == DHCPV4_OPT_PAD) ? 1 : 2 + opt->len)
 
 #endif /* _DHCPV4_H_ */

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -967,7 +967,8 @@ static bool dhcpv6_ia_on_link(const struct dhcpv6_ia_hdr *ia, struct dhcpv6_leas
 ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *iface,
 		const struct sockaddr_in6 *addr, const void *data, const uint8_t *end)
 {
-	struct dhcpv6_lease *first = NULL;
+	uint8_t first_key[16];
+	bool first_key_valid = false;
 	const struct dhcpv6_client_header *hdr = data;
 	time_t now = odhcpd_time();
 	uint16_t otype, olen, duid_len = 0;
@@ -1217,8 +1218,8 @@ proceed:
 						else
 							a->assigned_subnet_id = reqhint;
 
-						if (first)
-							memcpy(a->key, first->key, sizeof(a->key));
+						if (first_key_valid)
+							memcpy(a->key, first_key, sizeof(a->key));
 						else
 							odhcpd_urandom(a->key, sizeof(a->key));
 
@@ -1260,7 +1261,7 @@ proceed:
 			if (hdr->msg_type == DHCPV6_MSG_REQUEST)
 				handshake_len += sizeof(struct dhcpv6_auth_reconfigure);
 
-			if (accept_reconf && assigned && !first &&
+			if (accept_reconf && assigned && !first_key_valid &&
 				hdr->msg_type != DHCPV6_MSG_REBIND &&
 				buflen >= handshake_len) {
 				buf[0] = 0;
@@ -1290,7 +1291,8 @@ proceed:
 				buflen -= handshake_len;
 				response_len += handshake_len;
 
-				first = a;
+				memcpy(first_key, a->key, sizeof(first_key));
+				first_key_valid = true;
 			}
 
 			ia_response_len = build_ia(

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -813,7 +813,7 @@ static size_t build_ia(uint8_t *buf, size_t buflen, uint16_t status,
 					};
 
 					if (buflen < ia_len + sizeof(o_ia_a))
-						continue;
+						return 0;
 
 					memcpy(buf + ia_len, &o_ia_a, sizeof(o_ia_a));
 					ia_len += sizeof(o_ia_a);

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1026,6 +1026,14 @@ ssize_t dhcpv6_ia_handle_IAs(uint8_t *buf, size_t buflen, struct interface *ifac
 		if (!is_pd && !is_na)
 			continue;
 
+		/* RFC8415 §21.4 / §21.21: an IA_NA/IA_PD option carries at
+		 * least 12 bytes of fixed payload (iaid + t1 + t2) before any
+		 * sub-options. Without this guard, a crafted option with
+		 * olen < 12 lets us read ia->iaid/t1/t2 out of bounds (the
+		 * iterator only enforces odata + olen <= end). */
+		if (olen < sizeof(struct dhcpv6_ia_hdr) - DHCPV6_OPT_HDR_SIZE)
+			continue;
+
 		struct dhcpv6_ia_hdr *ia = (struct dhcpv6_ia_hdr*)&odata[-DHCPV6_OPT_HDR_SIZE];
 		size_t ia_response_len = 0;
 		uint8_t reqlen = (is_pd) ? 62 : 128;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1280,6 +1280,9 @@ proceed:
 					handshake_len += sizeof(auth);
 				}
 
+				if (handshake_len > buflen)
+					handshake_len = buflen;
+
 				buf += handshake_len;
 				buflen -= handshake_len;
 				response_len += handshake_len;
@@ -1398,6 +1401,9 @@ proceed:
 			a->bound = true;
 			apply_lease(a, true);
 		}
+
+		if (ia_response_len > buflen)
+			ia_response_len = buflen;
 
 		buf += ia_response_len;
 		buflen -= ia_response_len;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1280,12 +1280,8 @@ proceed:
 					};
 
 					memcpy(auth.key, a->key, sizeof(a->key));
-					memcpy(buf + handshake_len, &auth, sizeof(auth));
-					handshake_len += sizeof(auth);
+					memcpy(buf + 4, &auth, sizeof(auth));
 				}
-
-				if (handshake_len > buflen)
-					handshake_len = buflen;
 
 				buf += handshake_len;
 				buflen -= handshake_len;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -346,8 +346,14 @@ static bool assign_pd(struct interface *iface, struct dhcpv6_lease *assign)
 	if (iface->addr6_len < 1)
 		return false;
 
-	/* Try honoring the hint first */
-	uint32_t current = 1, asize = (1 << (64 - assign->length)) - 1;
+	/* Try honoring the hint first.
+	 *
+	 * Subnet-id slots per delegated prefix = 2^(64 - length); the literal
+	 * 1 is plain int, so shifting it by 32-63 bits is undefined behaviour
+	 * for short prefix lengths (the user can drive this via
+	 * dhcpv6_pd_min_len). Compute the shift in uint64_t and truncate.
+	 */
+	uint32_t current = 1, asize = (uint32_t)((1ULL << (64 - assign->length)) - 1);
 	if (assign->assigned_subnet_id) {
 		list_for_each_entry(c, &iface->ia_assignments, head) {
 			if (c->flags & OAF_DHCPV6_NA)
@@ -362,7 +368,7 @@ static bool assign_pd(struct interface *iface, struct dhcpv6_lease *assign)
 				return true;
 			}
 
-			current = (c->assigned_subnet_id + (1 << (64 - c->length)));
+			current = (uint32_t)(c->assigned_subnet_id + (1ULL << (64 - c->length)));
 		}
 	}
 
@@ -384,7 +390,7 @@ static bool assign_pd(struct interface *iface, struct dhcpv6_lease *assign)
 			return true;
 		}
 
-		current = (c->assigned_subnet_id + (1 << (64 - c->length)));
+		current = (uint32_t)(c->assigned_subnet_id + (1ULL << (64 - c->length)));
 	}
 
 	return false;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -1256,10 +1256,13 @@ proceed:
 			}
 
 			/* Reconfigure Accept */
-			if (accept_reconf && assigned && !first &&
-				hdr->msg_type != DHCPV6_MSG_REBIND) {
+			size_t handshake_len = 4;
+			if (hdr->msg_type == DHCPV6_MSG_REQUEST)
+				handshake_len += sizeof(struct dhcpv6_auth_reconfigure);
 
-				size_t handshake_len = 4;
+			if (accept_reconf && assigned && !first &&
+				hdr->msg_type != DHCPV6_MSG_REBIND &&
+				buflen >= handshake_len) {
 				buf[0] = 0;
 				buf[1] = DHCPV6_OPT_RECONF_ACCEPT;
 				buf[2] = 0;

--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -597,6 +597,9 @@ static size_t build_ia(uint8_t *buf, size_t buflen, uint16_t status,
 			.val = htons(status),
 		};
 
+		if (buflen < ia_len + sizeof(o_status))
+			return 0;
+
 		memcpy(buf + ia_len, &o_status, sizeof(o_status));
 		ia_len += sizeof(o_status);
 

--- a/src/dhcpv6-pxe.c
+++ b/src/dhcpv6-pxe.c
@@ -32,6 +32,11 @@ const struct ipv6_pxe_entry* ipv6_pxe_entry_new(uint32_t arch, const char* url) 
 	ipe->bootfile_url.type = htons(DHCPV6_OPT_BOOTFILE_URL);
 
 	if (arch == 0xFFFFFFFF) {
+		/* The "default" entry lives outside ipv6_pxe_list; if config
+		 * already supplied one (e.g. two boot6 sections without an
+		 * arch), free the previous one before replacing it, otherwise
+		 * it would leak until ipv6_pxe_clear() runs. */
+		free(ipv6_pxe_default);
 		ipv6_pxe_default = ipe;
 	}
 	else {

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -191,7 +191,7 @@ enum {
 	IOV_TOTAL
 };
 
-static void handle_nested_message(uint8_t *data, size_t len,
+static void handle_nested_message(uint8_t *data, size_t len, unsigned depth,
 				  struct dhcpv6_client_header **c_hdr, uint8_t **opts,
 				  uint8_t **end, struct iovec iov[IOV_TOTAL])
 {
@@ -215,25 +215,36 @@ static void handle_nested_message(uint8_t *data, size_t len,
 		return;
 	}
 
+	/* Each nested Relay-Forward is one relay hop; RFC8415 bounds a relay
+	 * chain via HOP_COUNT_LIMIT (defined in §7.6, enforced in §19.1.2),
+	 * so refuse to recurse deeper and avoid stack exhaustion on crafted
+	 * relay loops. */
+	if (depth >= DHCPV6_HOP_COUNT_LIMIT)
+		return;
+
 	dhcpv6_for_each_option(r_hdr->options, data + len, otype, olen, odata) {
 		if (otype == DHCPV6_OPT_RELAY_MSG) {
 			iov[IOV_RELAY_MSG].iov_base = odata + olen;
 			iov[IOV_RELAY_MSG].iov_len = (((uint8_t *)iov[IOV_NESTED].iov_base) +
 					iov[IOV_NESTED].iov_len) - (odata + olen);
-			handle_nested_message(odata, olen, c_hdr, opts, end, iov);
+			handle_nested_message(odata, olen, depth + 1, c_hdr, opts, end, iov);
 			return;
 		}
 	}
 }
 
 
-static void update_nested_message(uint8_t *data, size_t len, ssize_t pdiff)
+static void update_nested_message(uint8_t *data, size_t len, unsigned depth, ssize_t pdiff)
 {
 	struct dhcpv6_relay_header *hdr = (struct dhcpv6_relay_header*)data;
 	if (hdr->msg_type != DHCPV6_MSG_RELAY_FORW)
 		return;
 
 	hdr->msg_type = DHCPV6_MSG_RELAY_REPL;
+
+	/* Bound recursion to mirror handle_nested_message(). */
+	if (depth >= DHCPV6_HOP_COUNT_LIMIT)
+		return;
 
 	uint16_t otype, olen;
 	uint8_t *odata;
@@ -242,7 +253,7 @@ static void update_nested_message(uint8_t *data, size_t len, ssize_t pdiff)
 			olen += pdiff;
 			odata[-2] = (olen >> 8) & 0xff;
 			odata[-1] = olen & 0xff;
-			update_nested_message(odata, olen - pdiff, pdiff);
+			update_nested_message(odata, olen - pdiff, depth + 1, pdiff);
 			return;
 		}
 	}
@@ -656,7 +667,7 @@ static void handle_client_request(void *addr, void *data, size_t len,
 	};
 
 	if (hdr->msg_type == DHCPV6_MSG_RELAY_FORW)
-		handle_nested_message(data, len, &hdr, &opts, &opts_end, iov);
+		handle_nested_message(data, len, 0, &hdr, &opts, &opts_end, iov);
 
 	if (!IN6_IS_ADDR_MULTICAST((struct in6_addr *)dest_addr) && iov[IOV_NESTED].iov_len == 0 &&
 	    (hdr->msg_type == DHCPV6_MSG_SOLICIT || hdr->msg_type == DHCPV6_MSG_CONFIRM ||
@@ -779,7 +790,7 @@ static void handle_client_request(void *addr, void *data, size_t len,
 	}
 
 	if (iov[IOV_NESTED].iov_len > 0) /* Update length */
-		update_nested_message(data, len, iov[IOV_DEST].iov_len + iov[IOV_MAXRT].iov_len +
+		update_nested_message(data, len, 0, iov[IOV_DEST].iov_len + iov[IOV_MAXRT].iov_len +
 				      iov[IOV_RAPID_COMMIT].iov_len + iov[IOV_DNS].iov_len +
 				      iov[IOV_DNS_ADDR].iov_len + iov[IOV_SEARCH].iov_len +
 				      iov[IOV_SEARCH_DOMAIN].iov_len + iov[IOV_PDBUF].iov_len +

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -744,8 +744,14 @@ static void handle_client_request(void *addr, void *data, size_t len,
 					break;
 				}
 			}
-		} else if (otype == DHCPV6_OPT_CLIENT_ARCH) {
-			uint16_t arch_code = ntohs(((uint16_t*)odata)[0]);
+		} else if (otype == DHCPV6_OPT_CLIENT_ARCH && olen >= sizeof(uint16_t)) {
+			uint16_t arch_code;
+
+			/* odata is not guaranteed to be uint16-aligned, and
+			 * RFC5970 §3.3 mandates olen be a multiple of 2 with
+			 * at least one architecture entry — read defensively. */
+			memcpy(&arch_code, odata, sizeof(arch_code));
+			arch_code = ntohs(arch_code);
 			ipv6_pxe_serve_boot_url(arch_code, &iov[IOV_BOOTFILE_URL]);
 		}
 	}

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -532,7 +532,11 @@ static void handle_client_request(void *addr, void *data, size_t len,
 
 	uint16_t otype, olen;
 	uint8_t *odata;
-	uint16_t *reqopts = NULL;
+	/* OPTION_ORO payload is an array of uint16_t but the underlying buffer
+	 * isn't guaranteed to be 2-byte aligned (it's at an arbitrary offset
+	 * inside the packed wire packet), so keep it as a byte pointer and
+	 * memcpy each value out rather than casting to uint16_t *. */
+	uint8_t *reqopts = NULL;
 	size_t reqopts_cnt = 0;
 
 	/* FIXME: this should be merged with the second loop further down */
@@ -540,14 +544,17 @@ static void handle_client_request(void *addr, void *data, size_t len,
 		/* Requested options, array of uint16_t, RFC 8415 §21.7 */
 		if (otype == DHCPV6_OPT_ORO) {
 			reqopts_cnt = olen / sizeof(uint16_t);
-			reqopts = (uint16_t *)odata;
+			reqopts = odata;
 			break;
 		}
 	}
 
 	/* Requested options */
 	for (size_t i = 0; i < reqopts_cnt; i++) {
-		uint16_t opt = ntohs(reqopts[i]);
+		uint16_t opt;
+
+		memcpy(&opt, &reqopts[i * sizeof(uint16_t)], sizeof(opt));
+		opt = ntohs(opt);
 
 		switch (opt) {
 		case DHCPV6_OPT_SNTP_SERVERS:
@@ -703,8 +710,12 @@ static void handle_client_request(void *addr, void *data, size_t len,
 			iov[IOV_RAPID_COMMIT].iov_len = sizeof(rapid_commit);
 			o_rapid_commit = true;
 		} else if (otype == DHCPV6_OPT_ORO) {
-			for (int i=0; i < olen/2; i++) {
-				uint16_t option = ntohs(((uint16_t *)odata)[i]);
+			for (int i = 0; i < olen / 2; i++) {
+				uint16_t option;
+
+				/* odata is not guaranteed to be uint16-aligned. */
+				memcpy(&option, &odata[i * 2], sizeof(option));
+				option = ntohs(option);
 
 				switch (option) {
 #ifdef DHCPV4_SUPPORT

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -967,6 +967,14 @@ static void relay_client_request(struct sockaddr_in6 *source,
 	struct odhcpd_ipaddr *ip;
 	struct sockaddr_in6 s;
 
+	/* A bare UDP socket can deliver a zero/short payload; the relay-reply
+	 * path (relay_server_response) checks this but the client-side relay
+	 * did not. relay_client_request() reads h->msg_type, plus h->hop_count
+	 * for a RELAY_FORW, out of the relay header and forwards the rest
+	 * verbatim, so require at least those two leading header bytes. */
+	if (len < offsetof(struct dhcpv6_relay_header, link_address))
+		return;
+
 	switch (h->msg_type) {
 	/* Valid message types from clients */
 	case DHCPV6_MSG_SOLICIT:

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -250,10 +250,19 @@ static void update_nested_message(uint8_t *data, size_t len, unsigned depth, ssi
 	uint8_t *odata;
 	dhcpv6_for_each_option(hdr->options, data + len, otype, olen, odata) {
 		if (otype == DHCPV6_OPT_RELAY_MSG) {
-			olen += pdiff;
-			odata[-2] = (olen >> 8) & 0xff;
-			odata[-1] = olen & 0xff;
-			update_nested_message(odata, olen - pdiff, depth + 1, pdiff);
+			ssize_t newlen = (ssize_t)olen + pdiff;
+
+			/* olen was validated to lie within the buffer by the option
+			 * iterator. Reject a pdiff that would make the rewritten
+			 * RELAY_MSG length wrap the 16-bit field, which would also feed
+			 * a bogus length into the recursion below and walk options past
+			 * the end of the (untrusted) packet buffer. */
+			if (newlen < 0 || newlen > UINT16_MAX)
+				return;
+
+			odata[-2] = (newlen >> 8) & 0xff;
+			odata[-1] = newlen & 0xff;
+			update_nested_message(odata, olen, depth + 1, pdiff);
 			return;
 		}
 	}

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -317,6 +317,19 @@ static ssize_t dhcpv6_4o6_query(uint8_t *buf, size_t buflen,
 		return -1;
 	}
 
+	/* dhcpv4_handle_msg() reads the full BOOTP fixed header (op, htype,
+	 * hlen, hops, xid, secs, flags, ciaddr, yiaddr, siaddr, giaddr,
+	 * chaddr, sname, file, cookie = offsetof(options) bytes) before
+	 * parsing options. The normal DHCPv4 socket path enforces this via a
+	 * BPF filter, but the DHCPv4-over-DHCPv6 path bypasses that filter,
+	 * so validate the length here to prevent an out-of-bounds read on a
+	 * truncated DHCPV4_MSG option. RFC7341 §7.1 defines the DHCPv4 Message
+	 * option but mandates no minimum length, so this floor is ours. */
+	if (msgv4_len < offsetof(struct dhcpv4_message, options)) {
+		error("4o6: encapsulated DHCPv4 message too short (%u)", msgv4_len);
+		return -1;
+	}
+
 	// Dummy IPv4 address
 	memset(&addrv4, 0, sizeof(addrv4));
 	addrv4.sin_family = AF_INET;

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -715,10 +715,10 @@ static void handle_client_request(void *addr, void *data, size_t len,
 		}
 	}
 
-	if (dest.serverid_length == clientid.len && 
-	    !memcmp(clientid.buf, dest.serverid_buf, dest.serverid_length)) {
+	if (dest.serverid_length == clientid.len &&
+	    !memcmp(clientid.buf, dest.serverid_buf, ntohs(dest.serverid_length))) {
 		/* Bail if we are in a network loop where we talk with ourself */
-		return;		
+		return;
 	}
 
 	if (!IN6_IS_ADDR_MULTICAST((struct in6_addr *)dest_addr) && iov[IOV_NESTED].iov_len == 0 &&

--- a/src/ndp.c
+++ b/src/ndp.c
@@ -382,6 +382,15 @@ static void handle_solicit(void *addr, void *data, size_t len,
 	if (len < sizeof(*ip6) + sizeof(*req))
 		return; // Invalid total length
 
+	/* RFC4861 §7.1.1: a Neighbor Solicitation MUST be silently discarded
+	 * if the IP Hop Limit field is not 255 or the ICMP Code is non-zero.
+	 * The hop-limit check is what protects against off-link attackers
+	 * forging NS / DAD messages, so it must not be skipped. Because the
+	 * NDP socket is AF_PACKET (not a kernel-managed ICMPv6 socket), we
+	 * have to enforce it ourselves. */
+	if (ip6->ip6_hlim != 255 || req->nd_ns_hdr.icmp6_code != 0)
+		return;
+
 	if (IN6_IS_ADDR_LINKLOCAL(&req->nd_ns_target) ||
 			IN6_IS_ADDR_LOOPBACK(&req->nd_ns_target) ||
 			IN6_IS_ADDR_MULTICAST(&req->nd_ns_target))

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -587,8 +587,14 @@ static int cb_addr_valid(struct nl_msg *msg, void *arg)
 	memset(&oaddrs[ctxt->ret], 0, sizeof(oaddrs[ctxt->ret]));
 	oaddrs[ctxt->ret].prefix_len = ifa->ifa_prefixlen;
 
-	if (ifa->ifa_family == AF_INET)
-		oaddrs[ctxt->ret].netmask = htonl(~((1U << (32 - ifa->ifa_prefixlen)) - 1));
+	if (ifa->ifa_family == AF_INET) {
+		/* ifa_prefixlen is 0..32. A /0 prefix turns "32 - prefix" into a
+		 * 32-bit shift on a 32-bit type, which is undefined behaviour;
+		 * compute the host mask in 64-bit and truncate so /0 yields a
+		 * zero netmask as expected. */
+		uint32_t host_bits = (uint32_t)((1ULL << (32 - ifa->ifa_prefixlen)) - 1);
+		oaddrs[ctxt->ret].netmask = htonl(~host_bits);
+	}
 
 	nla_memcpy(&oaddrs[ctxt->ret].addr, nla_addr, sizeof(oaddrs[ctxt->ret].addr));
 

--- a/src/router.c
+++ b/src/router.c
@@ -902,6 +902,12 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 			dns_addrs6_cnt = 1;
 		}
 
+		/* The RDNSS len field is a uint8_t counting 8-byte units, so it
+		 * holds at most 127 addresses (1 + 2*127 == 255); drop any extra
+		 * so the on-wire length stays consistent with the bytes sent. */
+		if (dns_addrs6_cnt > 127)
+			dns_addrs6_cnt = 127;
+
 		if (dns_addrs6_cnt) {
 			dns_sz = sizeof(*dns) + dns_addrs6_cnt * sizeof(*dns_addrs6);
 
@@ -917,7 +923,11 @@ static int send_router_advert(struct interface *iface, const struct in6_addr *fr
 	iov[IOV_RA_DNS].iov_len = dns_sz;
 
 	/* DNS Search List aka DNSSL; RFC8106, §5.2 */
-	if (iface->ra_dns && iface->dns_search_len > 0) {
+	/* The DNSSL len field is a uint8_t counting 8-byte units, so the whole
+	 * option must fit in UINT8_MAX*8 bytes; skip it otherwise rather than
+	 * emit an option whose length field does not match its real size. */
+	if (iface->ra_dns && iface->dns_search_len > 0 &&
+	    sizeof(*search) + ((iface->dns_search_len + 7) & ~7) <= UINT8_MAX * 8) {
 		search_sz = sizeof(*search) + ((iface->dns_search_len + 7) & ~7);
 		search = alloca(search_sz);
 		memset(search, 0, search_sz);

--- a/src/router.c
+++ b/src/router.c
@@ -1174,7 +1174,7 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 	/* Rewrite options */
 	uint8_t *end = data + len;
 	uint8_t *mac_ptr = NULL;
-	struct in6_addr *dns_addrs6 = NULL;
+	struct in6_addr *dns_addrs6 = NULL, *dns_addrs6_orig = NULL;
 	size_t dns_addrs6_cnt = 0;
 	// MTU option
 	struct nd_opt_mtu *mtu_opt = NULL;
@@ -1247,9 +1247,24 @@ static void forward_router_advertisement(const struct interface *iface, uint8_t 
 	all_nodes.sin6_family = AF_INET6;
 	inet_pton(AF_INET6, ALL_IPV6_NODES, &all_nodes.sin6_addr);
 
+	/* Preserve the upstream DNS addresses: they are rewritten in place in the
+	 * single shared packet buffer, so without restoring them a later slave
+	 * would inherit a previous slave's rewritten values. */
+	if (dns_addrs6 && dns_addrs6_cnt > 0) {
+		dns_addrs6_orig = alloca(dns_addrs6_cnt * sizeof(*dns_addrs6_orig));
+		memcpy(dns_addrs6_orig, dns_addrs6, dns_addrs6_cnt * sizeof(*dns_addrs6_orig));
+	}
+
 	avl_for_each_element(&interfaces, c, avl) {
 		if (c->ra != MODE_RELAY || c->master)
 			continue;
+
+		/* Restore the upstream DNS addresses and MTU value that a previous
+		 * slave may have rewritten in the shared buffer. */
+		if (dns_addrs6_orig)
+			memcpy(dns_addrs6, dns_addrs6_orig, dns_addrs6_cnt * sizeof(*dns_addrs6));
+		if (mtu_opt)
+			mtu_opt->nd_opt_mtu_mtu = htonl(ingress_mtu_val);
 
 		/* Fixup source hardware address option */
 		if (mac_ptr)

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -361,7 +361,13 @@ static void statefiles_write_host(const char *ipbuf, const char *hostname, struc
 {
 	char exp_dn[DNS_MAX_NAME_LEN];
 
-	if (dn_expand(ctxt->iface->dns_search, ctxt->iface->dns_search + ctxt->iface->dns_search_len,
+	/* Since the DNS search-domain fallback was dropped, dns_search may
+	 * legitimately be NULL on interfaces with no configured domain. Skip
+	 * dn_expand() in that case to avoid pointer arithmetic on NULL and
+	 * libc-specific NULL handling in dn_expand(). */
+	if (ctxt->iface->dns_search && ctxt->iface->dns_search_len > 0 &&
+	    dn_expand(ctxt->iface->dns_search,
+		      ctxt->iface->dns_search + ctxt->iface->dns_search_len,
 		      ctxt->iface->dns_search, exp_dn, sizeof(exp_dn)) > 0)
 		fprintf(ctxt->fp, "%s\t%s.%s\t%s\n", ipbuf, hostname, exp_dn, hostname);
 	else

--- a/src/statefiles.c
+++ b/src/statefiles.c
@@ -51,11 +51,13 @@ static FILE *statefiles_open_tmp_file(int dirfd)
 		return NULL;
 
 	fd = openat(dirfd, ODHCPD_TMP_FILE, O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
-	if (fd < 0)
-		goto err;
+	if (fd < 0) {
+		error("Failed to create temporary file: %m");
+		return NULL;
+	}
 
 	if (lockf(fd, F_LOCK, 0) < 0)
-		goto err;
+		goto err_del;
 
 	if (ftruncate(fd, 0) < 0)
 		goto err_del;
@@ -67,10 +69,12 @@ static FILE *statefiles_open_tmp_file(int dirfd)
 	return fp;
 
 err_del:
-	unlinkat(dirfd, ODHCPD_TMP_FILE, 0);
-err:
-	close(fd);
+	/* Log before unlinkat()/close() so they don't clobber errno. The
+	 * old code also called close(fd) on the openat-failure path, which
+	 * meant close(-1) overwrote errno with EBADF before %m printed it. */
 	error("Failed to create temporary file: %m");
+	unlinkat(dirfd, ODHCPD_TMP_FILE, 0);
+	close(fd);
 	return NULL;
 }
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -52,7 +52,7 @@ static int handle_dhcpv4_leases(struct ubus_context *ctx, _o_unused struct ubus_
 				buf = blobmsg_alloc_string_buffer(&b, "duid", DUID_HEXSTRLEN + 1);
 				odhcpd_hexlify(buf, c->duid, c->duid_len);
 				blobmsg_add_string_buffer(&b);
-				blobmsg_add_u32(&b, "iaid", ntohl(c->iaid));
+				blobmsg_add_u32(&b, "iaid", c->iaid);
 			}
 
 			blobmsg_add_string(&b, "hostname", (c->hostname) ? c->hostname : "");


### PR DESCRIPTION
2a42d34 dhcpv6-ia: fix Reconfigure Accept Auth option write offset
5b28383 dhcpv6-ia: avoid dangling first lease pointer
6634b7a odhcpd: fix out of bounds write in dhcpv6_ia_handle_IAs
d08dbcc odhcpd: fix integer underflow in dhcpv6_ia_handle_IAs
d168c27 odhcpd: fix out-of-bounds write in build_ia
89d1877 dhcpv6-ia: signal buffer-full from build_ia() IA_ADDR branch
538b626 dhcpv6: validate rewritten RELAY_MSG length in update_nested_message()
48652c1 dhcpv4: pass &dest.sin_addr to inet_ntop() when logging
8b02a78 router: keep RA DNS option lengths within the uint8 length field
9707cf7 router: restore upstream DNS/MTU between relayed RAs
8706996 config: bound DNR 'mandatory' SvcParam key count
719fc3a dhcpv6-ia: validate IA_NA/IA_PD option size before reading header
9054585 dhcpv6: validate length and alignment when reading CLIENT_ARCH option
94d97d1 statefiles: clean up tmpfile error path
909847c dhcpv6-pxe: free previous default entry on replacement
f2cfc8d config: invert ipv6_pxe_from_uci() return value
6545d3d dhcpv6: avoid unaligned uint16_t reads in ORO option parsing
2830047 statefiles: skip dn_expand() when no search domain is configured
2db29c4 dhcpv4: copy ifname into arpreq without reading past the source
0721ab6 config: guard captive_portal_uri parsing against strdup() failure
b1adea2 dhcpv6: validate minimum length in relay_client_request()
9c78550 ndp: enforce RFC4861 §7.1.1 hop-limit and ICMP-code checks on NS
3553613 dhcpv4: never return NULL from dhcpv4_msg_to_string()
41b476d netlink: avoid 32-bit-wide shift when computing /0 IPv4 netmask
6644b46 dhcpv6-ia: avoid undefined shifts in assign_pd()
1c461b0 ubus: drop spurious ntohl() of DHCPv4 lease IAID
14a85c9 dhcpv4: honor Pad/End option encoding when iterating options
8637f4c dhcpv6: reject undersized encapsulated DHCPv4 messages in 4o6 path
f6571a4 dhcpv6: bound nested-relay recursion to HOP_COUNT_LIMIT
6907f28 dhcpv6: fix out-of-bounds read in self-loop detection memcmp