### PR TITLE
odhcpd: fix infinite loop on recvmsg error

### DIFF
--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -460,10 +460,11 @@ static void odhcpd_receive_packets(struct uloop_fd *u, _o_unused unsigned int ev
 
 		ssize_t len = recvmsg(u->fd, &msg, MSG_DONTWAIT);
 		if (len < 0) {
-			if (errno == EAGAIN)
-				break;
-			else
+			if (errno == EINTR)
 				continue;
+			else if (errno != EAGAIN)
+				error("Failed to recvmsg %d (%m)", u->fd);
+			break;
 		}
 
 


### PR DESCRIPTION
### Description
This PR fixes an issue where `odhcpd` can enter an infinite loop and consume 100% CPU when `recvmsg()` encounters an error other than `EAGAIN` (such as `EBADF`).

### Background
We observed that the `odhcpd` process was pinning a specific CPU core at 100% utilization. 

Investigating the running process with `strace` revealed that `recvmsg()` was being called continuously in a tight loop, relentlessly returning `EBADF` (Bad file descriptor) because the file descriptor had become invalid (`-1`).

`strace -f -c` output:
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    1.069867           1    762638    762638 recvmsg
------ ----------- ----------- --------- --------- ----------------
100.00    1.069867           1    762638    762638 total
```

`strace -f -e trace=recvmsg` output:
```
recvmsg(-1, {msg_namelen=28}, MSG_DONTWAIT) = -1 EBADF (Bad file descriptor)
recvmsg(-1, {msg_namelen=28}, MSG_DONTWAIT) = -1 EBADF (Bad file descriptor)
recvmsg(-1, {msg_namelen=28}, MSG_DONTWAIT) = -1 EBADF (Bad file descriptor)
...
```

The root cause was that when `recvmsg()` failed with a non-`EAGAIN` error, the loop inside `odhcpd_receive_packets()` would `continue` indefinitely instead of breaking out.

### Changes
- Modify the error handling in odhcpd_receive_packets() to also break out of the loop when a non-EAGAIN error occurs.
- Add unexpected `recvmsg` failure logging via `error()`.
- Handle `EINTR` by continuing the loop to prevent premature termination on signal interrupts.