### PR TITLE
Allow running as a non-root user

### DIFF
--- a/src/odhcpd.c
+++ b/src/odhcpd.c
@@ -151,11 +151,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (getuid() != 0) {
-		error("Must be run as root!");
-		return 2;
-	}
-
 	if (config.log_syslog) {
 		openlog("odhcpd", LOG_PERROR | LOG_PID, LOG_DAEMON);
 		setlogmask(LOG_UPTO(config.log_level));


### PR DESCRIPTION
odhcpd refuses to start under any uid but 0:

    src/odhcpd.c, main():

        if (getuid() != 0) {
                error("Must be run as root!");
                return 2;
        }

Nothing behind that line needs uid 0. Binding 67/547 needs `CAP_NET_BIND_SERVICE`, the raw ICMPv6 and AF_PACKET sockets need `CAP_NET_RAW`, and the rtnetlink and proxy-neigh writes need `CAP_NET_ADMIN`. These are capability checks, not uid checks. The commit removes the gate.

I ran this on an ipq807x router as odhcpd-ipv6only under uid 455 with `CapEff = CapAmb = 0x3400` (bits 10, 12, 13) and `NoNewPrivs: 1`. It holds the `:547` listener, answers `ubus call dhcp ipv6leases`, writes its lease and hosts files, and logs no socket() or bind() errors. The ipv6only build has no DHCPv4, and I have not run NDP relay mode under that uid.

An earlier version of this PR had a second commit that tolerated an unwritable `proxy_ndp`. I dropped it. A process holding `CAP_NET_ADMIN` gets the owner's mode bits on every net sysctl:

    net/sysctl_net.c, net_ctl_permissions():

        if (ns_capable_noaudit(net->user_ns, CAP_NET_ADMIN)) {
                int mode = (table->mode >> 6) & 7;
                return (mode << 6) | (mode << 3) | mode;

On the same router a jailed non-root shell with that capability writes `/proc/sys/net/ipv6/conf/<if>/proxy_ndp`, and fails with `EACCES` once the capability is removed.

Removing the gate is not enough on its own. The lease and hosts files, the 0600 mode on `/etc/config/dhcp` and ubusd's root-only default all need help from the caller. openwrt/openwrt#24558 is the OpenWrt side.