### PR TITLE
ubus: fold ephemeral dhcp sections from procd service data

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1098,7 +1098,8 @@ static int avl_ipv4_cmp(const void *k1, const void *k2, _o_unused void *ptr)
 	return memcmp(k1, k2, sizeof(struct in_addr));
 }
 
-int config_parse_interface(void *data, size_t len, const char *name, bool overwrite)
+int config_parse_interface(void *data, size_t len, const char *name,
+			   bool overwrite, bool ephemeral)
 {
 	struct interface *iface;
 	struct blob_attr *tb[IFACE_ATTR_MAX], *c;
@@ -1279,7 +1280,8 @@ int config_parse_interface(void *data, size_t len, const char *name, bool overwr
 
 	if ((c = tb[IFACE_ATTR_DHCPV4])) {
 		if ((mode = parse_mode(blobmsg_get_string(c))) >= 0) {
-			iface->dhcpv4 = config.main_dhcpv4 ? mode : MODE_DISABLED;
+			iface->dhcpv4 = (config.main_dhcpv4 || ephemeral) ?
+					mode : MODE_DISABLED;
 
 			if (iface->dhcpv4 != MODE_DISABLED)
 				iface->ignore = false;
@@ -1818,7 +1820,8 @@ static int set_interface(struct uci_section *s)
 	blob_buf_init(&b, 0);
 	uci_to_blob(&b, s, &interface_attr_list);
 
-	return config_parse_interface(blob_data(b.head), blob_len(b.head), s->e.name, true);
+	return config_parse_interface(blob_data(b.head), blob_len(b.head),
+				      s->e.name, true, false);
 }
 
 static void lease_cfg_delete_dhcpv6_leases(struct lease_cfg *lease_cfg)
@@ -2149,6 +2152,7 @@ static void reload_config(void)
 
 	vlist_flush(&lease_cfgs);
 
+	ubus_apply_service_data();
 	ubus_apply_network();
 
 	bool any_dhcpv6_slave = false, any_ra_slave = false, any_ndp_slave = false;

--- a/src/config.c
+++ b/src/config.c
@@ -2059,7 +2059,7 @@ static int ipv6_pxe_from_uci(struct uci_section* s)
 	return ipv6_pxe_entry_new(arch, url) ? 0 : -1;
 }
 
-void odhcpd_reload(void)
+static void reload_config(void)
 {
 	struct uci_context *uci = uci_alloc_context();
 	struct interface *master = NULL, *i, *tmp;
@@ -2222,6 +2222,23 @@ void odhcpd_reload(void)
 	}
 
 	uci_free_context(uci);
+}
+
+void odhcpd_reload(void)
+{
+	static bool active, pending;
+
+	if (active) {
+		pending = true;
+		return;
+	}
+
+	active = true;
+	do {
+		pending = false;
+		reload_config();
+	} while (pending);
+	active = false;
 }
 
 static void signal_reload(_o_unused struct uloop_signal *signal)

--- a/src/odhcpd.h
+++ b/src/odhcpd.h
@@ -572,7 +572,8 @@ void odhcpd_enum_addr6(struct interface *iface, struct dhcpv6_lease *lease,
 int odhcpd_parse_addr6_prefix(const char *str, struct in6_addr *addr, uint8_t *prefix);
 bool odhcpd_hostname_valid(const char *name);
 
-int config_parse_interface(void *data, size_t len, const char *iname, bool overwrite);
+int config_parse_interface(void *data, size_t len, const char *iname,
+			   bool overwrite, bool ephemeral);
 struct lease_cfg *config_find_lease_cfg_by_duid_and_iaid(const uint8_t *duid,
 							 const uint16_t len,
 							 const uint32_t iaid);
@@ -585,6 +586,7 @@ int config_set_lease_cfg_from_blobmsg(struct blob_attr *ba);
 int ubus_init(void);
 const char* ubus_get_ifname(const char *name);
 void ubus_apply_network(void);
+void ubus_apply_service_data(void);
 bool ubus_has_prefix(const char *name, const char *ifname);
 void ubus_bcast_dhcpv4_event(const char *type, const char *iface,
 			     const struct dhcpv4_lease *lease);
@@ -600,6 +602,11 @@ static inline const char *ubus_get_ifname(const char *name)
 }
 
 static inline void ubus_apply_network(void)
+{
+	return;
+}
+
+static inline void ubus_apply_service_data(void)
 {
 	return;
 }

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -379,13 +379,112 @@ void ubus_apply_network(void)
 
 			if (!c->ignore)
 				config_parse_interface(blobmsg_data(tb[IFACE_ATTR_DATA]),
-						blobmsg_data_len(tb[IFACE_ATTR_DATA]), c->name, false);
+						blobmsg_data_len(tb[IFACE_ATTR_DATA]),
+						c->name, false, false);
 		}
 
 		if (!matched)
 			config_parse_interface(blobmsg_data(tb[IFACE_ATTR_DATA]),
-					blobmsg_data_len(tb[IFACE_ATTR_DATA]), interface, false);
+					blobmsg_data_len(tb[IFACE_ATTR_DATA]),
+					interface, false, false);
 	}
+}
+
+
+enum {
+	SERVICE_ATTR_TYPE,
+	SERVICE_ATTR_INTERFACE,
+	SERVICE_ATTR_MAX
+};
+
+static const struct blobmsg_policy service_attrs[SERVICE_ATTR_MAX] = {
+	[SERVICE_ATTR_TYPE] = { .name = "type", .type = BLOBMSG_TYPE_STRING },
+	[SERVICE_ATTR_INTERFACE] = { .name = "interface", .type = BLOBMSG_TYPE_STRING },
+};
+
+static void apply_service_section(struct blob_attr *sec)
+{
+	struct blob_attr *tb[SERVICE_ATTR_MAX];
+	struct interface *iface;
+	const char *name;
+
+	if (blobmsg_type(sec) != BLOBMSG_TYPE_TABLE ||
+	    !blobmsg_check_attr(sec, false))
+		return;
+
+	blobmsg_parse(service_attrs, SERVICE_ATTR_MAX, tb,
+		      blobmsg_data(sec), blobmsg_data_len(sec));
+
+	if (!tb[SERVICE_ATTR_TYPE] ||
+	    strcmp(blobmsg_get_string(tb[SERVICE_ATTR_TYPE]), "dhcp"))
+		return;
+
+	if (!tb[SERVICE_ATTR_INTERFACE]) {
+		warn("Ignoring ephemeral dhcp section without interface");
+		return;
+	}
+
+	name = blobmsg_get_string(tb[SERVICE_ATTR_INTERFACE]);
+	iface = avl_find_element(&interfaces, name, iface, avl);
+	if (iface && iface->inuse) {
+		notice("Ignoring ephemeral dhcp section for '%s': already configured",
+		       name);
+		return;
+	}
+
+	config_parse_interface(blobmsg_data(sec), blobmsg_data_len(sec), NULL,
+			       true, true);
+}
+
+static void apply_instance_data(struct blob_attr *ins)
+{
+	struct blob_attr *cur, *sec;
+	unsigned rem, srem;
+
+	blobmsg_for_each_attr(cur, ins, rem) {
+		if (strcmp(blobmsg_name(cur), "dhcp") ||
+		    blobmsg_type(cur) != BLOBMSG_TYPE_ARRAY)
+			continue;
+
+		blobmsg_for_each_attr(sec, cur, srem)
+			apply_service_section(sec);
+	}
+}
+
+static void handle_service_data(_o_unused struct ubus_request *req,
+				_o_unused int type, struct blob_attr *msg)
+{
+	struct blob_attr *svc, *ins;
+	unsigned rem, irem;
+
+	if (!msg)
+		return;
+
+	blobmsg_for_each_attr(svc, msg, rem) {
+		if (blobmsg_type(svc) != BLOBMSG_TYPE_TABLE)
+			continue;
+
+		blobmsg_for_each_attr(ins, svc, irem) {
+			if (blobmsg_type(ins) == BLOBMSG_TYPE_TABLE)
+				apply_instance_data(ins);
+		}
+	}
+}
+
+
+void ubus_apply_service_data(void)
+{
+	uint32_t id;
+
+	if (!ubus)
+		return;
+
+	if (ubus_lookup_id(ubus, "service", &id))
+		return;
+
+	blob_buf_init(&b, 0);
+	blobmsg_add_string(&b, "type", "dhcp");
+	ubus_invoke(ubus, id, "get_data", b.head, handle_service_data, NULL, 3000);
 }
 
 


### PR DESCRIPTION
Fold ephemeral `dhcp` sections from procd instance data into the interface list on every reload: query `service get_data {"type":"dhcp"}` and feed each section through `config_parse_interface()`, sharing defaults and validation with UCI. UCI sections win collisions. The first commit defers a nested `odhcpd_reload()`, since libubus dispatches the pending netifd dump reply while the synchronous request waits.

A container manager can then declare DHCP, RA and NDP service on the container's own procd instance, tied to its lifetime: the section vanishes with the instance, which sends a final zero-lifetime RA and drops the leases. Ephemeral sections enable DHCPv4 regardless of `maindhcp`, which arbitrates UCI pool ownership with dnsmasq. firewall4 consumes service data the same way in `read_ubus()`.

Both commits were produced with an LLM coding agent working from a written brief: fold ephemeral sections from procd instance data into the interface list through the UCI code path, re-derive them on every reload, tear down withdrawn interfaces, let UCI win collisions, and tolerate an absent `service` object. Tested on x86/64 with dnsmasq running and `maindhcp=0`: DHCPv4 from the declared pool, RAs and stateful DHCPv6 on a container bridge, teardown on withdrawal, reconvergence after restart, leases intact across repeated reloads; all four build variants compile.
