### PR TITLE
dhcpv6-ia: skip invalid parent prefixes for PD routes

### DIFF
--- a/src/dhcpv6-ia.c
+++ b/src/dhcpv6-ia.c
@@ -298,6 +298,9 @@ static void __apply_lease(struct dhcpv6_lease *a,
 		if (ADDR_MATCH_PIO_FILTER(&addrs[i], a->iface))
 			continue;
 
+		if (!valid_prefix_length(a, addrs[i].prefix_len))
+			continue;
+
 		prefix = addrs[i].addr.in6;
 		prefix.s6_addr32[1] |= htonl(a->assigned_subnet_id);
 		prefix.s6_addr32[2] = prefix.s6_addr32[3] = 0;


### PR DESCRIPTION
The IA_PD reply path uses valid_prefix_length() to skip interface prefixes that cannot contain the delegated prefix, but __apply_lease() does not.

As a result, a /64 PD lease on an interface carrying both a shorter prefix and an on-link /64 can install a route for the on-link /64 via the downstream client, even though that prefix was never delegated.

Apply the same prefix-length validation before installing PD routes.

This keeps route installation consistent with the IA_PD reply path and prevents a delegated /64 from replacing the directly-connected route of a /64 parent prefix.

fixes #418 